### PR TITLE
feat: Add emoji support for special cards

### DIFF
--- a/ballsdex/core/admin/resources.py
+++ b/ballsdex/core/admin/resources.py
@@ -117,6 +117,7 @@ class SpecialResource(Model):
             display=displays.Image(width="40"),
             input_=inputs.Image(upload=upload, null=True),
         ),
+        "emoji",
     ]
 
     async def get_actions(self, request: Request) -> List[Action]:

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -16,7 +16,7 @@ from discord.gateway import DiscordWebSocket
 from ballsdex.settings import settings
 from ballsdex.core.dev import Dev
 from ballsdex.core.metrics import PrometheusServer
-from ballsdex.core.models import BlacklistedID, Special, Ball, balls
+from ballsdex.core.models import BlacklistedID, Special, Ball, balls, specials
 from ballsdex.core.commands import Core
 
 log = logging.getLogger("ballsdex.core.bot")
@@ -113,11 +113,16 @@ class BallsDexBot(commands.AutoShardedBot):
         now = datetime.now()
         self.special_cache = await Special.filter(start_date__lte=now, end_date__gt=now)
 
-    async def load_balls(self):
+    async def load_cache(self):
         balls.clear()
         for ball in await Ball.all():
             balls.append(ball)
         log.info(f"Loaded {len(balls)} balls")
+
+        specials.clear()
+        for special in await Special.all():
+            specials.append(special)
+        log.info(f"Loaded {len(specials)} specials")
 
     async def launch_shards(self) -> None:
         # override to add a log call on the number of shards that needs connecting
@@ -162,7 +167,7 @@ class BallsDexBot(commands.AutoShardedBot):
             f"{self.owner_ids} {'are' if len(self.owner_ids) > 1 else 'is'} set as the bot owner."
         )
 
-        await self.load_balls()
+        await self.load_cache()
         await self.load_blacklist()
         await self.load_special_cache()
         if self.blacklist:

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -86,5 +86,5 @@ class Core(commands.Cog):
         This is needed each time the database is updated, otherwise changes won't reflect until
         next start.
         """
-        await self.bot.load_caches()
+        await self.bot.load_cache()
         await ctx.message.add_reaction("✅")

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -79,12 +79,12 @@ class Core(commands.Cog):
 
     @commands.command()
     @commands.is_owner()
-    async def reloadballs(self, ctx: commands.Context):
+    async def reloadcache(self, ctx: commands.Context):
         """
-        Reload the cache of countryballs.
+        Reload the cache of database models.
 
         This is needed each time the database is updated, otherwise changes won't reflect until
         next start.
         """
-        await self.bot.load_balls()
+        await self.bot.load_caches()
         await ctx.message.add_reaction("✅")

--- a/ballsdex/core/models.py
+++ b/ballsdex/core/models.py
@@ -86,7 +86,10 @@ class Special(models.Model):
     democracy_card = fields.CharField(max_length=200)
     dictatorship_card = fields.CharField(max_length=200)
     union_card = fields.CharField(max_length=200)
-    emoji = fields.CharField(max_length=40)
+    emoji = fields.CharField(
+        max_length=20,
+        description="Either a unicode character or a discord emoji ID",
+    )
 
     def __str__(self) -> str:
         return self.name

--- a/ballsdex/core/models.py
+++ b/ballsdex/core/models.py
@@ -224,9 +224,10 @@ class BallInstance(models.Model):
         if self.special:
             special_emoji = ""
             try:
-                if not use_custom_emoji or not bot:
+                emoji_id = int(self.specialcard.emoji)
+                special_emoji = bot.get_emoji(emoji_id) if bot else "⚡ "
+                if not use_custom_emoji:
                     return "⚡ "
-                special_emoji = bot.get_emoji(int(self.specialcard.emoji))
             except ValueError:
                 special_emoji = self.specialcard.emoji
             if special_emoji:

--- a/ballsdex/packages/players/countryballs_paginator.py
+++ b/ballsdex/packages/players/countryballs_paginator.py
@@ -34,9 +34,10 @@ class CountryballsSelector(Pages):
             emoji = self.bot.get_emoji(int(ball.countryball.emoji_id))
             favorite = "❤️ " if ball.favorite else ""
             shiny = "✨ " if ball.shiny else ""
+            special = ball.special_emoji(self.bot, False)
             options.append(
                 discord.SelectOption(
-                    label=f"{favorite}{shiny}#{ball.pk:0X} {ball.countryball.country}",
+                    label=f"{favorite}{shiny}{special}#{ball.pk:0X} {ball.countryball.country}",
                     description=f"ATK: {ball.attack_bonus:+d}% • HP: {ball.health_bonus:+d}% • "
                     f"Caught on {ball.catch_date.strftime('%d/%m/%y %H:%M')}",
                     emoji=emoji,

--- a/migrations/models/17_20230415141405_update.sql
+++ b/migrations/models/17_20230415141405_update.sql
@@ -1,0 +1,4 @@
+-- upgrade --
+ALTER TABLE "special" ADD "emoji" VARCHAR(40) NOT NULL;
+-- downgrade --
+ALTER TABLE "special" DROP COLUMN "emoji";


### PR DESCRIPTION
Adds emoji support for special events which will show in trades etc

NOTE: Due to a discord limitation, you cannot show custom emojis in autocomplete/selection models.

Another limitation, the database just stores raw text like `:egg:`, to support showing unicode emojis in those model fields we will need to change handling to convert emoji to its unicode equivalent which is not part of this PR. Instead a generic lightning emoji is used to signify a special card. 