### PR TITLE
Fix ability to give away balls in an active trade

### DIFF
--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -67,6 +67,7 @@ class BallsDexBot(commands.AutoShardedBot):
         self._shutdown = 0
         self.blacklist: set[int] = set()
         self.blacklist_guild: set[int] = set()
+        self.locked_balls: set[int] = set()
 
     async def start_prometheus_server(self):
         self.prometheus_server = PrometheusServer(

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -31,6 +31,7 @@ class DonationRequest(View):
         new_player: Player,
     ):
         super().__init__(timeout=120)
+        self.bot = bot
         self.original_interaction = interaction
         self.countryball = countryball
         self.new_player = new_player
@@ -47,6 +48,7 @@ class DonationRequest(View):
         for item in self.children:
             item.disabled = True
         await self.original_interaction.followup.edit_message("@original", view=self)
+        self.bot.locked_balls.remove(self.countryball.id)
 
     @button(
         style=discord.ButtonStyle.success, emoji="\N{HEAVY CHECK MARK}\N{VARIATION SELECTOR-16}"
@@ -77,6 +79,7 @@ class DonationRequest(View):
             content=interaction.message.content + "\n\N{CROSS MARK} The donation was denied.",
             view=self,
         )
+        self.bot.locked_balls.remove(self.countryball.id)
 
 
 class SortingChoices(enum.Enum):

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -24,7 +24,11 @@ log = logging.getLogger("ballsdex.packages.countryballs")
 
 class DonationRequest(View):
     def __init__(
-        self, interaction: discord.Interaction, countryball: BallInstance, new_player: Player
+        self,
+        bot: "BallsDexBot",
+        interaction: discord.Interaction,
+        countryball: BallInstance,
+        new_player: Player,
     ):
         super().__init__(timeout=120)
         self.original_interaction = interaction
@@ -59,6 +63,7 @@ class DonationRequest(View):
             + "\n\N{WHITE HEAVY CHECK MARK} The donation was accepted!",
             view=self,
         )
+        self.bot.locked_balls.remove(self.countryball.id)
 
     @button(
         style=discord.ButtonStyle.danger,
@@ -400,7 +405,12 @@ class Players(commands.GroupCog, group_name=settings.players_group_cog_name):
         if user.bot:
             await interaction.response.send_message("You cannot donate to bots.")
             return
-
+        if countryball.id in self.bot.locked_balls:
+            await interaction.response.send_message(
+                "This countryball is currently locked for a trade. Please try again later."
+            )
+            return
+        self.bot.locked_balls.add(countryball.id)
         new_player, _ = await Player.get_or_create(discord_id=user.id)
         old_player = countryball.player
 
@@ -408,18 +418,20 @@ class Players(commands.GroupCog, group_name=settings.players_group_cog_name):
             await interaction.response.send_message(
                 f"You cannot give a {settings.collectible_name} to yourself."
             )
+            self.bot.locked_balls.remove(countryball.id)
             return
         if new_player.donation_policy == DonationPolicy.ALWAYS_DENY:
             await interaction.response.send_message(
                 "This player does not accept donations. You can use trades instead."
             )
+            self.bot.locked_balls.remove(countryball.id)
             return
         elif new_player.donation_policy == DonationPolicy.REQUEST_APPROVAL:
             await interaction.response.send_message(
                 f"Hey {user.mention}, {interaction.user.name} wants to give you "
                 f"{countryball.description(include_emoji=True, bot=interaction.client)}!\n"
                 "Do you accept this donation?",
-                view=DonationRequest(interaction, countryball, new_player),
+                view=DonationRequest(self.bot, interaction, countryball, new_player),
             )
             return
 
@@ -433,3 +445,4 @@ class Players(commands.GroupCog, group_name=settings.players_group_cog_name):
             f"{countryball.description(short=True, include_emoji=True, bot=self.bot)} to "
             f"{user.mention}!"
         )
+        self.bot.locked_balls.remove(countryball.id)

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -169,6 +169,15 @@ class Trade(commands.GroupCog):
                 ephemeral=True,
             )
             return
+        if countryball.id in self.bot.locked_balls:
+            await interaction.followup.send(
+                "This countryball is currently in an active trade or donation, "
+                "please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        self.bot.locked_balls.add(countryball.id)
         trader.proposal.append(countryball)
         await interaction.followup.send(
             f"{countryball.countryball.country} added.", ephemeral=True
@@ -209,3 +218,4 @@ class Trade(commands.GroupCog):
         await interaction.response.send_message(
             f"{countryball.countryball.country} removed.", ephemeral=True
         )
+        self.bot.locked_balls.remove(countryball.id)

--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -381,6 +381,7 @@ class TradeMenu:
 
         for countryball in valid_transferable_countryballs:
             await countryball.save()
+            self.bot.locked_balls.remove(countryball.id)
 
     async def confirm(self, trader: TradingUser) -> bool:
         """


### PR DESCRIPTION
This PR achieves the first suggestion brought up in core chat. It will keep track of all balls in an active trade or donation.

Suggestion 2 to limit trades to 1 globally would have to be another PR