### PR TITLE
Remove ability to user lookup on list

### DIFF
--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -419,6 +419,7 @@ class BallsDexBot(commands.AutoShardedBot):
 
             if isinstance(error, app_commands.TransformerError):
                 await send("One of the arguments provided cannot be parsed.")
+                log.debug(f"Failed running converter", exc_info=error.original)
                 return
 
             log.error(

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -419,7 +419,7 @@ class BallsDexBot(commands.AutoShardedBot):
 
             if isinstance(error, app_commands.TransformerError):
                 await send("One of the arguments provided cannot be parsed.")
-                log.debug(f"Failed running converter", exc_info=error.original)
+                log.debug("Failed running converter", exc_info=error.original)
                 return
 
             log.error(

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -417,6 +417,10 @@ class BallsDexBot(commands.AutoShardedBot):
                 )
                 # still including traceback because it may be a programming error
 
+            if isinstance(error, app_commands.TransformerError):
+                await send("One of the arguments provided cannot be parsed.")
+                return
+
             log.error(
                 f"Error in slash command {interaction.command.name}", exc_info=error.original
             )

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -117,7 +117,7 @@ class Players(commands.GroupCog, group_name=settings.players_group_cog_name):
     async def list(
         self,
         interaction: discord.Interaction["BallsDexBot"],
-        user: discord.User | None = None,
+        user: discord.Member | None = None,
         sort: SortingChoices | None = None,
         reverse: bool = False,
     ):


### PR DESCRIPTION
Removes the User argument on balls list, replaces with Member and adds a transformer error to bot on error to handle stuff that cannot be converted.