### PR TITLE
[Trade] Unlock balls on clear.

### DIFF
--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -71,6 +71,8 @@ class TradeView(View):
                 ephemeral=True,
             )
         else:
+            for countryball in trader.proposal:
+                await countryball.unlock()
             trader.proposal.clear()
             await interaction.response.send_message("Proposal cleared.", ephemeral=True)
 
@@ -80,6 +82,8 @@ class TradeView(View):
         style=discord.ButtonStyle.danger,
     )
     async def cancel(self, interaction: discord.Interaction, button: Button):
+        for countryball in self.trade.trader1.proposal + self.trade.trader2.proposal:
+            await countryball.unlock()
         await self.trade.user_cancel(self.trade._get_trader(interaction.user))
         await interaction.response.send_message("Trade has been cancelled.", ephemeral=True)
 

--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -82,8 +82,6 @@ class TradeView(View):
         style=discord.ButtonStyle.danger,
     )
     async def cancel(self, interaction: discord.Interaction, button: Button):
-        for countryball in self.trade.trader1.proposal + self.trade.trader2.proposal:
-            await countryball.unlock()
         await self.trade.user_cancel(self.trade._get_trader(interaction.user))
         await interaction.response.send_message("Trade has been cancelled.", ephemeral=True)
 


### PR DESCRIPTION
Fix a bug where balls are not unlocked from both clearing and cancelling a trade.

Resolves #214.