### PR TITLE
[core] For cooldown show active timer

### DIFF
--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -4,9 +4,9 @@ import asyncio
 import inspect
 import logging
 import math
+import time
 import types
 from datetime import datetime
-import time
 from typing import TYPE_CHECKING, cast
 
 import aiohttp

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -6,6 +6,7 @@ import logging
 import math
 import types
 from datetime import datetime
+import time
 from typing import TYPE_CHECKING, cast
 
 import aiohttp
@@ -419,7 +420,7 @@ class BallsDexBot(commands.AutoShardedBot):
             if isinstance(error, app_commands.CommandOnCooldown):
                 await send(
                     "This command is on cooldown. Please retry "
-                    f"in {math.ceil(error.retry_after)} seconds."
+                    f"in <t:{time.time() + math.ceil(error.retry_after)}:R> seconds."
                 )
                 return
             await send("You are not allowed to use that command.")

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -420,7 +420,7 @@ class BallsDexBot(commands.AutoShardedBot):
             if isinstance(error, app_commands.CommandOnCooldown):
                 await send(
                     "This command is on cooldown. Please retry "
-                    f"in <t:{time.time() + math.ceil(error.retry_after)}:R> seconds."
+                    f"<t:{math.ceil(time.time() + error.retry_after)}:R>."
                 )
                 return
             await send("You are not allowed to use that command.")


### PR DESCRIPTION
I imported `time` because `datetime` is much more limiting, and kind of useless. Works with Discord, verified it.