### PR TITLE
Small fix when comparing names

### DIFF
--- a/ballsdex/packages/countryballs/components.py
+++ b/ballsdex/packages/countryballs/components.py
@@ -55,7 +55,7 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             )
             return
         if self.ball.model.catch_names:
-            possible_names = (self.ball.name.lower(), *self.ball.model.catch_names.split(";"))
+            possible_names = (self.ball.name.lower(), *map(lambda names : names.lower(), self.ball.model.catch_names.split(";")))
         else:
             possible_names = (self.ball.name.lower(),)
         if self.name.value.lower().strip() in possible_names:

--- a/ballsdex/packages/countryballs/components.py
+++ b/ballsdex/packages/countryballs/components.py
@@ -55,7 +55,10 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             )
             return
         if self.ball.model.catch_names:
-            possible_names = (self.ball.name.lower(), *map(lambda names : names.lower(), self.ball.model.catch_names.split(";")))
+            possible_names = (
+                self.ball.name.lower(),
+                *map(lambda names: names.lower(), self.ball.model.catch_names.split(";")),
+            )
         else:
             possible_names = (self.ball.name.lower(),)
         if self.name.value.lower().strip() in possible_names:


### PR DESCRIPTION
Dear Ballsdex developer team,
Is it possible that possible names for countryballs can sometimes not match due to the fact that input from the user is lowered and the text field in the Balls model -> possible_names can accidently contain uppercase letters. Shouldn't something like this be done to prevent it from mismatching or am I mistaken and something is already done to avoid this. I have opened a pr for this reason.
Thanks,
HappyBee