### PR TITLE
removing version because it is not needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 x-common-env-vars:
   - &postgres-db
     POSTGRES_DB=ballsdex


### PR DESCRIPTION
fixes the warning version is obsolete every self host has