### PR TITLE
Add missing space from /config disable

### DIFF
--- a/ballsdex/packages/config/cog.py
+++ b/ballsdex/packages/config/cog.py
@@ -92,7 +92,7 @@ class Config(commands.GroupCog):
             self.bot.dispatch("ballsdex_settings_change", guild, enabled=False)
             await interaction.response.send_message(
                 f"{settings.bot_name} is now disabled in this server. Commands will still be "
-                f"available, but the spawn of new {settings.plural_collectible_name}"
+                f"available, but the spawn of new {settings.plural_collectible_name} "
                 "is suspended.\nTo re-enable the spawn, use the same command."
             )
         else:


### PR DESCRIPTION
Adds a missing space from if you disable spawning via /config disable, as it would previously display as this:

```
BallsDex is now disabled in this server. Commands will still be available, but the spawn of new countryballsis suspended.
To re-enable the spawn, use the same command.
```

however it now displays this:

```
BallsDex is now disabled in this server. Commands will still be available, but the spawn of new countryballs is suspended.
To re-enable the spawn, use the same command.
```

(credits to @seifdafisherman on Discord/GitHub for finding this, just thought i'd try to make a quick patch for it)
https://canary.discord.com/channels/1049118743101452329/1284830182691180696