### PR TITLE
Modernize Discord server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BallsDex Discord Bot
 
-[![Discord server](https://discordapp.com/api/guilds/1049118743101452329/embed.png)](https://discord.gg/Qn2Rkdkxwc)
+[![Discord server](https://img.shields.io/discord/1049118743101452329?color=7489d5&logo=discord&logoColor=ffffff)](https://discord.gg/Qn2Rkdkxwc)
 [![Pre-commit](https://github.com/laggron42/BallsDex-DiscordBot/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/laggron42/BallsDex-DiscordBot/actions/workflows/pre-commit.yml)
 [![Issues](https://img.shields.io/github/issues/laggron42/BallsDex-DiscordBot)](https://github.com/laggron42/BallsDex-DiscordBot/issues)
 [![discord.py](https://img.shields.io/badge/discord-py-blue.svg)](https://github.com/Rapptz/discord.py)


### PR DESCRIPTION
This is a bit of a stupid pull request, but my inner ocd really wants the badges to match with each other, so I’ve replaced the stock Discord API badge displaying the online counter, with one from shields.io that matches the rest of the badges more similarly, and with a modernised logo and look overall.