### PR TITLE
[core] wording fix on bot start-up

### DIFF
--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -318,7 +318,7 @@ class BallsDexBot(commands.AutoShardedBot):
 
         synced_cogs = await self.tree.sync()
         grammar = "" if synced_cogs == 1 else "s"
-        if synced_commands:
+        if synced_cogs:
             log.info(f"Synced {len(synced_cogs)} cog{grammar}.")
             try:
                 self.assign_ids_to_app_commands(synced_cogs)

--- a/ballsdex/core/bot.py
+++ b/ballsdex/core/bot.py
@@ -316,12 +316,12 @@ class BallsDexBot(commands.AutoShardedBot):
         else:
             log.info("No package loaded.")
 
-        synced_commands = await self.tree.sync()
-        grammar = "" if synced_commands == 1 else "s"
+        synced_cogs = await self.tree.sync()
+        grammar = "" if synced_cogs == 1 else "s"
         if synced_commands:
-            log.info(f"Synced {len(synced_commands)} command{grammar}.")
+            log.info(f"Synced {len(synced_cogs)} cog{grammar}.")
             try:
-                self.assign_ids_to_app_commands(synced_commands)
+                self.assign_ids_to_app_commands(synced_cogs)
             except Exception:
                 log.error("Failed to assign IDs to app commands", exc_info=True)
         else:


### PR DESCRIPTION
on "synced x commands", changing the commands to cogs, as commands is misleading