### PR TITLE
[trade] change donation message if having to request approval

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -611,7 +611,8 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         )
         if new_player.donation_policy == DonationPolicy.REQUEST_APPROVAL:
             await interaction.followup.send(
-                f"{interaction.user.mention}, you just gave {settings.collectible_name} {cb_txt} to {user.mention}!",
+                f"{interaction.user.mention}, you just gave the "
+                f"{settings.collectible_name} {cb_txt} to {user.mention}!",
                 allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
             )
         else:

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -611,10 +611,15 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             + f" (`{countryball.attack_bonus:+}%/{countryball.health_bonus:+}%`)"
         )
         if favorite:
+            mentions = []
+            if new_player.can_be_mentioned:
+                mentions.append(new_player.discord_id)
+            if old_player.can_be_mentioned:
+                mentions.append(old_player.discord_id)
             await interaction.followup.send(
                 f"{interaction.user.mention}, you just gave the "
                 f"{settings.collectible_name} {cb_txt} to {user.mention}!",
-                allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
+                allowed_mentions=discord.AllowedMentions(users=mentions),
             )
         else:
             await interaction.followup.send(

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -609,10 +609,16 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             countryball.description(short=True, include_emoji=True, bot=self.bot, is_trade=True)
             + f" (`{countryball.attack_bonus:+}%/{countryball.health_bonus:+}%`)"
         )
-        await interaction.followup.send(
-            f"You just gave the {settings.collectible_name} {cb_txt} to {user.mention}!",
-            allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
-        )
+        if new_player.donation_policy == DonationPolicy.REQUEST_APPROVAL:
+            await interaction.followup.send(
+                f"{interaction.user.mention}, you just gave {settings.collectible_name} {cb_txt} to {user.mention}!",
+                allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
+            )
+        else:
+            await interaction.followup.send(
+                f"You just gave the {settings.collectible_name} {cb_txt} to {user.mention}!",
+                allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
+            )
         await countryball.unlock()
 
     @app_commands.command()

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -610,12 +610,12 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             countryball.description(short=True, include_emoji=True, bot=self.bot, is_trade=True)
             + f" (`{countryball.attack_bonus:+}%/{countryball.health_bonus:+}%`)"
         )
+        mentions = []
+        if new_player.can_be_mentioned:
+            mentions.append(new_player.discord_id)
+        if old_player.can_be_mentioned:
+            mentions.append(old_player.discord_id)
         if favorite:
-            mentions = []
-            if new_player.can_be_mentioned:
-                mentions.append(new_player.discord_id)
-            if old_player.can_be_mentioned:
-                mentions.append(old_player.discord_id)
             await interaction.followup.send(
                 f"{interaction.user.mention}, you just gave the "
                 f"{settings.collectible_name} {cb_txt} to {user.mention}!",
@@ -624,7 +624,7 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         else:
             await interaction.followup.send(
                 f"You just gave the {settings.collectible_name} {cb_txt} to {user.mention}!",
-                allowed_mentions=discord.AllowedMentions(users=new_player.can_be_mentioned),
+                allowed_mentions=discord.AllowedMentions(users=mentions),
             )
         await countryball.unlock()
 

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -529,7 +529,8 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
                 ephemeral=True,
             )
             return
-        if countryball.favorite:
+        favorite = countryball.favorite
+        if favorite:
             view = ConfirmChoiceView(
                 interaction,
                 accept_message=f"{settings.collectible_name.title()} donated.",
@@ -609,7 +610,7 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             countryball.description(short=True, include_emoji=True, bot=self.bot, is_trade=True)
             + f" (`{countryball.attack_bonus:+}%/{countryball.health_bonus:+}%`)"
         )
-        if new_player.donation_policy == DonationPolicy.REQUEST_APPROVAL:
+        if favorite:
             await interaction.followup.send(
                 f"{interaction.user.mention}, you just gave the "
                 f"{settings.collectible_name} {cb_txt} to {user.mention}!",


### PR DESCRIPTION
If a user has request approval on, then the followup message confirming it references the ephemeral message - thus making it hard to see where it comes from