### PR TITLE
[admin] Fix file path in `save_file`

### DIFF
--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -27,13 +27,13 @@ FILENAME_RE = re.compile(r"^(.+)(\.\S+)$")
 
 
 async def save_file(attachment: discord.Attachment) -> Path:
-    path = Path(f"./static/uploads/{attachment.filename}")
+    path = Path(f"./admin_panel/media/{attachment.filename}")
     match = FILENAME_RE.match(attachment.filename)
     if not match:
         raise TypeError("The file you uploaded lacks an extension.")
     i = 1
     while path.exists():
-        path = Path(f"./static/uploads/{match.group(1)}-{i}{match.group(2)}")
+        path = Path(f"./admin_panel/media/{match.group(1)}-{i}{match.group(2)}")
         i = i + 1
     await attachment.save(path)
     return path

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -36,7 +36,7 @@ async def save_file(attachment: discord.Attachment) -> Path:
         path = Path(f"./admin_panel/media/{match.group(1)}-{i}{match.group(2)}")
         i = i + 1
     await attachment.save(path)
-    return path
+    return path.relative_to("./admin_panel/media/")
 
 
 class Balls(app_commands.Group):


### PR DESCRIPTION
Due to the latest admin panel changes, the static folder was switched to `admin_panel/media`, however, the `save_file` function in `ballsdex/packages/admin/balls.py` still uses the `/static/uploads` folder.