### PR TITLE
[migrations] Fix incorrect file path in migrations

### DIFF
--- a/migrations/models/20_20230725165036_update.sql
+++ b/migrations/models/20_20230725165036_update.sql
@@ -23,12 +23,12 @@ ALTER TABLE "special" DROP COLUMN "dictatorship_card";
 ALTER TABLE "ball" ADD CONSTRAINT "fk_ball_regime_d7fd92a9" FOREIGN KEY ("regime_id") REFERENCES "regime" ("id") ON DELETE CASCADE;
 ALTER TABLE "ball" ADD CONSTRAINT "fk_ball_economy_cfe9c5c3" FOREIGN KEY ("economy_id") REFERENCES "economy" ("id") ON DELETE SET NULL;
 INSERT INTO "economy" ("name", "icon") VALUES
-    ('Capitalist', '/ballsdex/core/image_generator/src/capitalist.png'),
-    ('Communist', '/ballsdex/core/image_generator/src/communist.png');
+    ('Capitalist', 'capitalist.png'),
+    ('Communist', 'communist.png');
 INSERT INTO "regime" ("name", "background") VALUES
-    ('Democracy', '/ballsdex/core/image_generator/src/democracy.png'),
-    ('Dictatorship', '/ballsdex/core/image_generator/src/dictatorship.png'),
-    ('Union', '/ballsdex/core/image_generator/src/union.png');
+    ('Democracy', 'democracy.png'),
+    ('Dictatorship', 'dictatorship.png'),
+    ('Union', 'union.png');
 UPDATE "ball" SET "economy_id" = "economy" WHERE "economy" != 3;
 UPDATE "ball" SET "economy_id" = null WHERE "economy" = 3;
 UPDATE "ball" SET "regime_id" = "regime";

--- a/migrations/models/36_20241009120300_update.sql
+++ b/migrations/models/36_20241009120300_update.sql
@@ -5,7 +5,7 @@ ALTER TABLE "special" ALTER COLUMN "end_date" DROP NOT NULL;
 WITH shiny_id AS (
     INSERT INTO "special" (name, catch_phrase, rarity, emoji, background) VALUES
     ('Shiny', '**It''s a shiny countryball!**', 0.00048828125,
-    '✨', '/ballsdex/core/image_generator/src/shiny.png')
+    '✨', 'shiny.png')
     RETURNING id)
 UPDATE "ballinstance" SET "special_id" = (SELECT id FROM shiny_id) WHERE "shiny" = true;
 
@@ -16,10 +16,10 @@ ALTER TABLE "ballinstance" ADD "shiny" BOOL NOT NULL  DEFAULT False;
 UPDATE "ballinstance" SET "shiny" = true
 FROM "special" s
 WHERE s.id = special_id
-AND s.background = '/ballsdex/core/image_generator/src/shiny.png';
+AND s.background = 'shiny.png';
 
 DELETE FROM "special" WHERE
-background = '/ballsdex/core/image_generator/src/shiny.png';
+background = 'shiny.png';
 
 ALTER TABLE "special" ALTER COLUMN "start_date" SET NOT NULL;
 ALTER TABLE "special" ALTER COLUMN "end_date" SET NOT NULL;


### PR DESCRIPTION
Regimes, shinies, and economies will still use the old file path. When you clone Ballsdex and try to spawn something, it will output an error.