### PR TITLE
[trade] Add trade_id arg in /trade view

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -7,8 +7,8 @@ from cachetools import TTLCache
 from discord import app_commands
 from discord.ext import commands
 from discord.utils import MISSING
-from tortoise.expressions import Q
 from tortoise.exceptions import DoesNotExist
+from tortoise.expressions import Q
 
 from ballsdex.core.models import BallInstance, Player
 from ballsdex.core.models import Trade as TradeModel

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -443,7 +443,7 @@ class Trade(commands.GroupCog):
                 trade = await TradeModel.get(id=trade_id).prefetch_related("player1", "player2")
             except DoesNotExist:
                 await interaction.response.send_message(
-                    f"Trade with id #{trade_id} not found.", ephemeral=True
+                    f"Trade with ID #{trade_id} not found.", ephemeral=True
                 )
                 return
 


### PR DESCRIPTION
### Description of the changes
Adds a trade_id arg in /trade view, so that a user can check a previous trade they've done.

### Were the changes in this PR tested?
Yes, except the "if interaction.user.id not in (trade.player1.discord_id, trade.player2.discord_id):" check.