### PR TITLE
[bot] Make unregistered players accept the TOS before using the bot

### DIFF
--- a/ballsdex/core/utils/accept_tos.py
+++ b/ballsdex/core/utils/accept_tos.py
@@ -1,0 +1,83 @@
+from typing import Optional
+
+import discord
+from discord.ui import Button, View, button
+
+from ballsdex.core.models import Player
+from ballsdex.settings import settings
+
+
+def activation_embed() -> discord.Embed:
+    return discord.Embed(
+        colour=0x00D936,
+        title=f"{settings.bot_name} activation",
+        description=(
+            f"To start using {settings.bot_name}, you must "
+            f"read and accept the [Terms of Service]({settings.terms_of_service}).\n\n"
+            "As a summary, these are the rules of the bot:\n"
+            f"- No farming (spamming or creating servers for {settings.plural_collectible_name})\n"
+            f"- Selling or exchanging {settings.plural_collectible_name} "
+            "against money or other goods is forbidden\n"
+            "- Do not attempt to abuse the bot's internals\n"
+            "**Not respecting these rules will lead to a blacklist.**"
+        ),
+    )
+
+
+class UserAcceptTOS(View):
+    """
+    Button prompting the user to accept the terms of service.
+    """
+
+    def __init__(self,interaction: discord.Interaction):
+        super().__init__()
+        self.value = None
+        self.original_interaction = interaction
+        self.message: Optional[discord.Message] = None
+
+        self.add_item(
+            Button(
+                style=discord.ButtonStyle.link,
+                label="Terms of Service",
+                url=settings.terms_of_service,
+            )
+        )
+        self.add_item(
+            Button(
+                style=discord.ButtonStyle.link,
+                label="Privacy policy",
+                url=settings.privacy_policy,
+            )
+        )
+
+    @button(
+        label="Accept",
+        style=discord.ButtonStyle.success,
+        emoji="\N{HEAVY CHECK MARK}\N{VARIATION SELECTOR-16}",
+    )
+    async def accept_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await Player.create(discord_id=interaction.user.id)
+        await interaction.response.send_message(
+            "You have accepted the terms of service, you can now continue with playing the bot.",
+            ephemeral=True,
+        )
+
+        self.value = True
+        self.stop()
+
+        if self.message:
+            button.disabled = True
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass
+
+    async def on_timeout(self) -> None:
+        if self.message:
+            for item in self.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass

--- a/ballsdex/core/utils/accept_tos.py
+++ b/ballsdex/core/utils/accept_tos.py
@@ -31,7 +31,6 @@ class UserAcceptTOS(View):
 
     def __init__(self,interaction: discord.Interaction):
         super().__init__()
-        self.value = None
         self.original_interaction = interaction
         self.message: Optional[discord.Message] = None
 
@@ -61,8 +60,6 @@ class UserAcceptTOS(View):
             "You have accepted the terms of service, you can now continue with playing the bot.",
             ephemeral=True,
         )
-
-        self.value = True
         self.stop()
 
         if self.message:

--- a/ballsdex/packages/config/cog.py
+++ b/ballsdex/packages/config/cog.py
@@ -6,23 +6,11 @@ from discord.ext import commands
 
 from ballsdex.core.models import GuildConfig
 from ballsdex.packages.config.components import AcceptTOSView
+from ballsdex.core.utils.accept_tos import activation_embed
 from ballsdex.settings import settings
 
 if TYPE_CHECKING:
     from ballsdex.core.bot import BallsDexBot
-
-activation_embed = discord.Embed(
-    colour=0x00D936,
-    title=f"{settings.bot_name} activation",
-    description=f"To enable {settings.bot_name} in your server, you must "
-    f"read and accept the [Terms of Service]({settings.terms_of_service}).\n\n"
-    "As a summary, these are the rules of the bot:\n"
-    f"- No farming (spamming or creating servers for {settings.plural_collectible_name})\n"
-    f"- Selling or exchanging {settings.plural_collectible_name} "
-    "against money or other goods is forbidden\n"
-    "- Do not attempt to abuse the bot's internals\n"
-    "**Not respecting these rules will lead to a blacklist**",
-)
 
 
 @app_commands.default_permissions(manage_guild=True)
@@ -67,7 +55,8 @@ class Config(commands.GroupCog):
                 return
 
         view = AcceptTOSView(interaction, channel, user)
-        message = await channel.send(embed=activation_embed, view=view)
+        embed = activation_embed()
+        message = await channel.send(embed=embed, view=view)
         view.message = message
 
         await interaction.response.send_message(


### PR DESCRIPTION
### Description of the changes

If a user tries to run a command, but there is no registered players for their discord ID, they need to accept the TOS in an embed+view similar to the one used by /config channel.
resolves #568

### Were the changes in this PR tested?

Yes