### PR TITLE
Fix bug in balls create.

### DIFF
--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -566,10 +566,12 @@ class Balls(app_commands.Group):
             return
         emoji = interaction.client.get_emoji(int(emoji_id))
         if not emoji:
-            await interaction.response.send_message(
+            emoji = interaction.client.fetch_application_emoji(int(emoji_id))
+            if not emoji:
+             await interaction.response.send_message(
                 "The bot does not have access to the given emoji.", ephemeral=True
-            )
-            return
+             )
+             return
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         default_path = Path("./ballsdex/core/image_generator/src/default.png")


### PR DESCRIPTION
### Description of the changes

<!--
-->
Some people enter an ID of one of their's bots emoji but the bot searches for the emoji in one of the servers that it's in,  therefore the bot says "The bot does not have access to the given emoji.". I fixed that.

### Were the changes in this PR tested?

<!--
-->
Yes.

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
