### PR TITLE
Move capacity description based on length of title

### DIFF
--- a/ballsdex/core/image_generator/image_gen.py
+++ b/ballsdex/core/image_generator/image_gen.py
@@ -73,7 +73,10 @@ def draw_card(ball_instance: "BallInstance", media_path: str = "./admin_panel/me
         stroke_width=2,
         stroke_fill=(0, 0, 0, 255),
     )
-    for i, line in enumerate(textwrap.wrap(f"Ability: {ball.capacity_name}", width=26)):
+    
+    cap_name = textwrap.wrap(f"Ability: {ball.capacity_name}", width=26)
+
+    for i, line in enumerate(cap_name):
         draw.text(
             (100, 1050 + 100 * i),
             line,
@@ -84,12 +87,13 @@ def draw_card(ball_instance: "BallInstance", media_path: str = "./admin_panel/me
         )
     for i, line in enumerate(textwrap.wrap(ball.capacity_description, width=32)):
         draw.text(
-            (60, 1300 + 80 * i),
+            (60, 1100 + 100*len(cap_name) + 80*i),
             line,
             font=capacity_description_font,
             stroke_width=1,
             stroke_fill=(0, 0, 0, 255),
         )
+    
     draw.text(
         (320, 1670),
         str(ball_instance.health),

--- a/ballsdex/core/image_generator/image_gen.py
+++ b/ballsdex/core/image_generator/image_gen.py
@@ -73,7 +73,7 @@ def draw_card(ball_instance: "BallInstance", media_path: str = "./admin_panel/me
         stroke_width=2,
         stroke_fill=(0, 0, 0, 255),
     )
-    
+
     cap_name = textwrap.wrap(f"Ability: {ball.capacity_name}", width=26)
 
     for i, line in enumerate(cap_name):
@@ -87,13 +87,13 @@ def draw_card(ball_instance: "BallInstance", media_path: str = "./admin_panel/me
         )
     for i, line in enumerate(textwrap.wrap(ball.capacity_description, width=32)):
         draw.text(
-            (60, 1100 + 100*len(cap_name) + 80*i),
+            (60, 1100 + 100 * len(cap_name) + 80 * i),
             line,
             font=capacity_description_font,
             stroke_width=1,
             stroke_fill=(0, 0, 0, 255),
         )
-    
+
     draw.text(
         (320, 1670),
         str(ball_instance.health),


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

This is a pretty small change that moves the ability description up one line in the event that the ability name is one line long. 

Example below; details of card hidden because it contains PII and whatnot. The only relevant part is the spacing between the ability name and description, which on the previous fork would be padded an extra 100px.

![image](https://github.com/user-attachments/assets/eeb74e2b-56d8-4d7e-8f6d-4b29a1459467)

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes, tested on my fork (along with other changes) and with dummy data on this branch

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
