### PR TITLE
Change setup of Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,6 @@ admin_panel/static
 pgbackups
 config.yml
 .env
-ballsdex.log
+ballsdex.log*
 venv
 __pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 admin_panel/media
 admin_panel/static
+pgbackups
+config.yml
+.env
+ballsdex.log
 venv
 __pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+admin_panel/media
+admin_panel/static
+venv
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.13.0-bookworm
+FROM python:3.13.0-alpine
 
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ ENV PYTHONFAULTHANDLER=1 \
   PYTHONHASHSEED=random \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
-  PIP_DEFAULT_TIMEOUT=100
+  PIP_DEFAULT_TIMEOUT=100 \
+  PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install poetry==2.0.1
 
 WORKDIR /code
-COPY poetry.lock pyproject.toml /code/
+
+COPY poetry.lock pyproject.toml ./
+RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi --no-root && rm -rf $POETRY_CACHE_DIR
 
 COPY . /code
 
 RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
-
-# wait for postgres to be ready
-CMD ["sleep", "2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.13.0-alpine
+FROM python:3.13.2-alpine3.21
 
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,21 +15,18 @@ services:
     environment:
       - *postgres-url
     depends_on:
-      - postgres-db
+      migration:
+        condition: service_started
+      postgres-db:
+        condition: service_healthy
     # ports:
     #   - "15260:15260"
     networks:
       - internal
     volumes:
-      - type: bind
-        source: ./
-        target: /code
+      - ./:/code
     tty: true
-    command: >
-      bash -c "
-      cd admin_panel &&
-      poetry run python3 manage.py migrate --no-input --fake-initial &&
-      cd .. && poetry run python3 -m ballsdex"
+    command: "poetry --quiet run python3 -m ballsdex"
 
   admin-panel:
     image: ballsdex
@@ -43,18 +40,32 @@ services:
       # if serving the admin panel online, copy the file "production.example.py" and uncomment
       # - DJANGO_SETTINGS_MODULE=admin_panel.settings.production
     depends_on:
-      - postgres-db
+      migration:
+        condition: service_started
+      postgres-db:
+        condition: service_healthy
     volumes:
-      - type: bind
-        source: ./
-        target: /code
+      - ./:/code
     tty: true
     working_dir: /code/admin_panel
-    command: >
-      bash -c "
-      poetry run python3 manage.py migrate --no-input --fake-initial &&
-      poetry run python3 manage.py collectstatic --no-input &&
-      poetry run uvicorn admin_panel.asgi:application --host 0.0.0.0"
+    command: "poetry --quiet run uvicorn admin_panel.asgi:application --host 0.0.0.0"
+
+    migration:
+      image: ballsdex
+      build: .
+      environment:
+        - *postgres-url
+      volumes:
+        - ./:/code
+      depends_on:
+        postgres-db:
+          condition: service_healthy
+      working_dir: /code/admin_panel
+      command: >
+        sh -c "
+        poetry --quiet run python3 manage.py migrate --no-input --fake-initial &&
+        poetry --quiet run python3 manage.py collectstatic --no-input
+        "
 
   postgres-db:
     image: postgres
@@ -72,6 +83,11 @@ services:
       - internal
     volumes:  # Persist the db data
       - database-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ballsdex}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   postgres-backup:
     image: prodrigestivill/postgres-backup-local
@@ -80,7 +96,8 @@ services:
     volumes:
       - ./pgbackups:/backups
     depends_on:
-      - postgres-db
+      postgres-db:
+        condition: service_healthy
     networks:
       - internal
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - *postgres-url
     depends_on:
       migration:
-        condition: service_started
+        condition: service_completed_successfully
       postgres-db:
         condition: service_healthy
     # ports:
@@ -23,7 +23,7 @@ services:
     networks:
       - internal
     volumes:
-      - ./:/code
+      - "./:/code"
     tty: true
     command: "poetry --quiet run python3 -m ballsdex"
 
@@ -40,31 +40,33 @@ services:
       # - DJANGO_SETTINGS_MODULE=admin_panel.settings.production
     depends_on:
       migration:
-        condition: service_started
+        condition: service_completed_successfully
       postgres-db:
         condition: service_healthy
     volumes:
-      - ./:/code
+      - "./:/code"
     tty: true
     working_dir: /code/admin_panel
     command: "poetry --quiet run uvicorn admin_panel.asgi:application --host 0.0.0.0"
 
-    migration:
-      image: ballsdex
-      build: .
-      environment:
-        - *postgres-url
-      volumes:
-        - ./:/code
-      depends_on:
-        postgres-db:
-          condition: service_healthy
-      working_dir: /code/admin_panel
-      command: >
-        sh -c "
-        poetry --quiet run python3 manage.py migrate --no-input --fake-initial &&
-        poetry --quiet run python3 manage.py collectstatic --no-input
-        "
+  migration:
+    image: ballsdex
+    build: .
+    networks:
+      - internal
+    environment:
+      - *postgres-url
+    volumes:
+      - ./:/code
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    working_dir: /code/admin_panel
+    command: >
+      sh -c "
+      poetry --quiet run python3 manage.py migrate --no-input --fake-initial &&
+      poetry --quiet run python3 manage.py collectstatic --no-input
+      "
 
   postgres-db:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ x-common-env-vars:
     "BALLSDEXBOT_DB_URL=postgres://ballsdex:${POSTGRES_PASSWORD}@postgres:5432/ballsdex"
 
 services:
-
   bot:
     restart: "no"
     image: ballsdex


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

This PR adjusts the setup of the dockerfile & docker compose to do the following

#### Dockerfile changes
- Rebase on Alpine instead of on Debian—it's lighter and builds faster
- Disable pycache; it's not needed in docker and clutters the directories
- Move the initial poetry install to before the code is copied. Because Docker caches builds, this ensures that the build will only re-install dependencies if the poetry file changes; this should make the vast majority of builds significantly faster since we no longer install a heap of dependencies
- Remove poetry cache after build so it isn't included in the final image.
- Remove the 2s delay for postgres (see docker-compose.yml changes)

#### Dockerignore changes
 - This PR adds a dockerignore containing files that shouldn't be embedded in the image
 - For example, before this, any change to the logfile would force a rebuild (which would also re-install dependencies prior to this), which is needlessly wasteful and also bloats the size of the image.
 - Now, only code changes should get docker to rebuild instead of using the cached image.
 
#### Docker-compose.yml changes
 - This restructures the docker-compose.yml to rely upon healthchecks and depends_on for migration and postgres rather than the old method of running a migration for both services before running the service
 - Postgres is given a healthcheck using pg_isready
 - All other services depend on condition: service_healthy, so they will only start once postgres indicates that it is ready to recieve requests.
 - Added a migration service: this runs once, before the admin_panel and ballsdex services, since they depend on service_completed_successfully.
 - Because of this, we can stop running the migration twice (once for admin panel and once for ballsdex) while still ensuring migration takes place before the bot launches.
 - Also, swapped the volume mounts from explicitly saying bind mount to just using ./:/code, since it's the default anyways.

### Were the changes in this PR tested?

Yes, changes tested on this fork from a clean DB & config (I did not have a used DB to test with, but that should probably be tested before this is merged), and my fork has been running with similar changes for months with no problems.

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->

- [ ] Test on instance that contains data
- [ ] Ensure there are no shell dependencies that Alpine does not have (I didn't see any but you never know)
