### PR TITLE
[settings] remove default invite & privacy/tos urls.

### DIFF
--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -204,10 +204,10 @@ about:
   github-link: https://github.com/laggron42/BallsDex-DiscordBot
 
   # valid invite for a Discord server
-  discord-invite: https://discord.gg/ballsdex  # BallsDex official server
+  discord-invite: https://discord.gg/INVITE_CODE
 
-  terms-of-service: https://gist.github.com/laggron42/52ae099c55c6ee1320a260b0a3ecac4e
-  privacy-policy: https://gist.github.com/laggron42/1eaa122013120cdfcc6d27f9485fe0bf
+  terms-of-service: https://gist.github.com/ # replace with your own link
+  privacy-policy: https://gist.github.com/ # replace with your own link
 
 # WORK IN PROGRESS, DOES NOT FULLY WORK
 # override the name "countryball" in the bot


### PR DESCRIPTION
### Description of the changes

Removes the default ballsdex url and tos/privacy policy.

### Were the changes in this PR tested?

closes #574 