### PR TITLE
[balls duplicate] Add limit arg, extend the limit from 50, plural check

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -674,7 +674,10 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
     @app_commands.command()
     @app_commands.checks.cooldown(1, 60, key=lambda i: i.user.id)
     async def duplicate(
-        self, interaction: discord.Interaction["BallsDexBot"], type: DuplicateType
+        self,
+        interaction: discord.Interaction["BallsDexBot"],
+        type: DuplicateType,
+        limit: int | None = None,
     ):
         """
         Shows your most duplicated countryballs or specials.
@@ -683,6 +686,8 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         ----------
         type: DuplicateType
             Type of duplicate to check (countryballs or specials).
+        limit: int | None
+            The amount of countryballs to show, can only be used with `countryballs`.
         """
         await interaction.response.defer(thinking=True, ephemeral=True)
 
@@ -694,33 +699,39 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         if is_special:
             queryset = queryset.filter(special_id__isnull=False).prefetch_related("special")
             annotations = {"name": "special__name", "emoji": "special__emoji"}
-            limit = 5
+            apply_limit = False
         else:
             queryset = queryset.filter(ball__tradeable=True)
             annotations = {"name": "ball__country", "emoji": "ball__emoji_id"}
-            limit = 50
+            apply_limit = True
 
-        results = (
-            await queryset.annotate(count=Count("id"))
+        query = (
+            queryset.annotate(count=Count("id"))
             .group_by(*annotations.values())
             .order_by("-count")
-            .limit(limit)
-            .values(*annotations.values(), "count")
         )
+
+        if apply_limit and limit is not None:
+            query = query.limit(limit)
+
+        query = query.values(*annotations.values(), "count")
+        results = await query
 
         if not results:
             await interaction.followup.send(
                 f"You don't have any {type.value} duplicates in your inventory.", ephemeral=True
             )
             return
+
         entries = [
             {
                 "name": item[annotations["name"]],
-                "emoji": self.bot.get_emoji(item[annotations["emoji"]])
-                or item[annotations["emoji"]],
+                "emoji": (
+                    self.bot.get_emoji(item[annotations["emoji"]]) or item[annotations["emoji"]]
+                ),
                 "count": item["count"],
             }
-            for i, item in enumerate(results)
+            for item in results
         ]
 
         source = DuplicateViewMenu(interaction, entries, type.value)

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -706,9 +706,7 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             apply_limit = True
 
         query = (
-            queryset.annotate(count=Count("id"))
-            .group_by(*annotations.values())
-            .order_by("-count")
+            queryset.annotate(count=Count("id")).group_by(*annotations.values()).order_by("-count")
         )
 
         if apply_limit and limit is not None:

--- a/ballsdex/packages/balls/countryballs_paginator.py
+++ b/ballsdex/packages/balls/countryballs_paginator.py
@@ -112,6 +112,8 @@ class DuplicateViewMenu(Pages):
             balls = await BallInstance.filter(
                 special__name=item.values[0], player__discord_id=interaction.user.id
             ).count()
+
+        plural = settings.collectible_name if balls == 1 else settings.plural_collectible_name
         await interaction.followup.send(
-            f"You have {balls:,} {item.values[0]} {settings.collectible_name}."
+            f"You have {balls:,} {item.values[0]} {plural}."
         )

--- a/ballsdex/packages/balls/countryballs_paginator.py
+++ b/ballsdex/packages/balls/countryballs_paginator.py
@@ -114,6 +114,4 @@ class DuplicateViewMenu(Pages):
             ).count()
 
         plural = settings.collectible_name if balls == 1 else settings.plural_collectible_name
-        await interaction.followup.send(
-            f"You have {balls:,} {item.values[0]} {plural}."
-        )
+        await interaction.followup.send(f"You have {balls:,} {item.values[0]} {plural}.")


### PR DESCRIPTION
### Description of the changes

Adds an optional limit arg, if the value is 0 or more than the amount of balls that the user owns it shows all, the limit is ignored on all specials. It also extends the limit from 50 to all, and also adds a plural check when a user clicks on a ball in the menu.

### Were the changes in this PR tested?

Yes, but with 3 balls and 2 specials only, not more.
