### PR TITLE
Configurable spawn messages

### DIFF
--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -89,7 +89,6 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             )
             return
 
-        # Good to catch ball now
         ball, has_caught_before = await self.view.catch_ball(
             interaction.user, player=player, guild=interaction.guild
         )

--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -60,29 +60,45 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
 
         player, _ = await Player.get_or_create(discord_id=interaction.user.id)
         if self.view.caught:
+            slow_message = random.choice(settings.slow_messages).format(
+                user=interaction.user.mention,
+                collectible=settings.collectible_name,
+                ball=self.view.name,
+                collectibles=settings.plural_collectible_name,
+            )
+
             await interaction.followup.send(
-                f"{interaction.user.mention} I was caught already!",
+                slow_message,
                 ephemeral=True,
                 allowed_mentions=discord.AllowedMentions(users=player.can_be_mentioned),
             )
             return
 
-        if self.view.is_name_valid(self.name.value):
-            ball, has_caught_before = await self.view.catch_ball(
-                interaction.user, player=player, guild=interaction.guild
+        if not self.view.is_name_valid(self.name.value):
+            wrong_message = random.choice(settings.wrong_messages).format(
+                user=interaction.user.mention,
+                collectible=settings.collectible_name,
+                ball=self.view.name,
+                collectibles=settings.plural_collectible_name,
             )
 
             await interaction.followup.send(
-                f"{interaction.user.mention} {self.view.get_message(ball, has_caught_before)}",
-                allowed_mentions=discord.AllowedMentions(users=player.can_be_mentioned),
-            )
-            await interaction.followup.edit_message(self.view.message.id, view=self.view)
-        else:
-            await interaction.followup.send(
-                f"{interaction.user.mention} Wrong name!",
+                wrong_message,
                 allowed_mentions=discord.AllowedMentions(users=player.can_be_mentioned),
                 ephemeral=False,
             )
+            return
+
+        # Good to catch ball now
+        ball, has_caught_before = await self.view.catch_ball(
+            interaction.user, player=player, guild=interaction.guild
+        )
+
+        await interaction.followup.send(
+            self.view.get_catch_message(ball, has_caught_before, interaction.user.mention),
+            allowed_mentions=discord.AllowedMentions(users=player.can_be_mentioned),
+        )
+        await interaction.followup.edit_message(self.view.message.id, view=self.view)
 
 
 class BallSpawnView(View):
@@ -377,7 +393,7 @@ class BallSpawnView(View):
 
         return ball, is_new
 
-    def get_message(self, ball: BallInstance, new_ball: bool) -> str:
+    def get_catch_message(self, ball: BallInstance, new_ball: bool, mention: str) -> str:
         """
         Generate a user-facing message after a ball has been caught.
 
@@ -397,7 +413,18 @@ class BallSpawnView(View):
                 f"This is a **new {settings.collectible_name}** "
                 "that has been added to your completion!"
             )
+
+        caught_message = (
+            random.choice(settings.caught_messages).format(
+                user=mention,
+                collectible=settings.collectible_name,
+                ball=self.name,
+                collectibles=settings.plural_collectible_name,
+            )
+            + " "
+        )
+
         return (
-            f"You caught **{self.name}!** "
-            f"`(#{ball.pk:0X}, {ball.attack_bonus:+}%/{ball.health_bonus:+}%)`\n\n{text}"
+            caught_message
+            + f"`(#{ball.pk:0X}, {ball.attack_bonus:+}%/{ball.health_bonus:+}%)`\n\n{text}"
         )

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -192,12 +192,13 @@ def read_settings(path: "Path"):
         settings.sentry_dsn = sentry.get("dsn")
         settings.sentry_environment = sentry.get("environment")
 
-    settings.spawn_messages = content["catch"]["spawn_msgs"] or ["A wild {1} appeared!"]
-    settings.caught_messages = content["catch"]["caught_msgs"] or ["{0} You caught **{2}**!"]
-    settings.wrong_messages = content["catch"]["wrong_msgs"] or ["{0} Wrong name!"]
-    settings.slow_messages = content["catch"]["slow_msgs"] or [
-        "{0} Sorry, this {1} was caught already!"
-    ]
+    if catch := content.get("catch"):
+        settings.spawn_messages = catch.get("spawn_msgs") or ["A wild {1} appeared!"]
+        settings.caught_messages = catch.get("caught_msgs") or ["{0} You caught **{2}**!"]
+        settings.wrong_messages = catch.get("wrong_msgs") or ["{0} Wrong name!"]
+        settings.slow_messages = catch.get("slow_msgs") or [
+            "{0} Sorry, this {1} was caught already!"
+        ]
 
     log.info("Settings loaded.")
 

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -193,11 +193,11 @@ def read_settings(path: "Path"):
         settings.sentry_environment = sentry.get("environment")
 
     if catch := content.get("catch"):
-        settings.spawn_messages = catch.get("spawn_msgs") or ["A wild {1} appeared!"]
-        settings.caught_messages = catch.get("caught_msgs") or ["{0} You caught **{2}**!"]
-        settings.wrong_messages = catch.get("wrong_msgs") or ["{0} Wrong name!"]
+        settings.spawn_messages = catch.get("spawn_msgs") or ["A wild {collectible} appeared!"]
+        settings.caught_messages = catch.get("caught_msgs") or ["{user} You caught **{ball}**!"]
+        settings.wrong_messages = catch.get("wrong_msgs") or ["{user} Wrong name!"]
         settings.slow_messages = catch.get("slow_msgs") or [
-            "{0} Sorry, this {1} was caught already!"
+            "{user} Sorry, this {collectible} was caught already!"
         ]
 
     log.info("Settings loaded.")

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -346,6 +346,7 @@ catch:
 
 
 def update_settings(path: "Path"):
+    print("Updating yaml!")
     content = path.read_text()
 
     add_owners = True

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -347,7 +347,6 @@ catch:
 
 
 def update_settings(path: "Path"):
-    print("Updating yaml!")
     content = path.read_text()
 
     add_owners = True

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -461,7 +461,8 @@ sentry:
 catch:
   # Add any number of messages to each of these categories. The bot will select a random
   # one each time.
-  # {user} is mention. {collectible} is collectible name. {ball} is ball name.
+  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and
+  # {collectibles} is collectible plural.
   caught_msgs:
     - "{user} You caught **{ball}**!"
   wrong_msgs:

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -358,7 +358,7 @@ def update_settings(path: "Path"):
     add_spawn_manager = "spawn-manager" not in content
     add_django = "Admin panel related settings" not in content
     add_sentry = "sentry:" not in content
-    add_catch = "catch:" not in content
+    add_catch_messages = "catch:" not in content
 
     for line in content.splitlines():
         if line.startswith("owners:"):
@@ -455,7 +455,7 @@ sentry:
     environment: "production"
 """
 
-    if add_catch:
+    if add_catch_messages:
         content += """
 catch:
   # Add any number of messages to each of these categories. The bot will select a random
@@ -483,6 +483,7 @@ catch:
             add_spawn_manager,
             add_django,
             add_sentry,
+            add_catch_messages,
         )
     ):
         path.write_text(content)


### PR DESCRIPTION
### Description of the changes

This PR allows users to configure spawn, catch, slow, and wrong messages within the config.yml

I didn't make it configurable from the DB because a) I don't think people are changing this that much b) db calls are slow (comparatively) and there are a lot of messages sent and lastly and most importantly c) I don't want to deal with DB nonsense

Users change format strings in the config.yml, and the bot picks a random one, formats it, and sends it instead of the prior hardcoded strings. It provides the ball name, the collectible singular and plural, and a mention for the user. I did not weight the messages, because I don't think I would use that and can't really think of a usecase.

I think I did all the yml things right, but I'm not sure, because that thing is a terrifying agglomeration of every change to the config since Ballsdex began.

This shouldn't change the user experience for ballsdex users at all (unless you want to) but makes it easier for other dexes to configure and differentiate their dex from stock bd.

### Were the changes in this PR tested?

Yes, tested for each message type, with 2 messages (responded randomly and seemingly correctly). My fork has had a similar feature for several months, and I've not had problems there either. 
