### PR TITLE
Let the wrong name message say what the submitter did wrong

### DIFF
--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -75,12 +75,19 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             return
 
         if not self.view.is_name_valid(self.name.value):
+            if len(self.name.value) > 500:
+                # seems like about the right number
+                wrong_name = "Sorry, entered name too long"
+            else:
+                wrong_name = self.name.value
+
+
             wrong_message = random.choice(settings.wrong_messages).format(
                 user=interaction.user.mention,
                 collectible=settings.collectible_name,
                 ball=self.view.name,
                 collectibles=settings.plural_collectible_name,
-                wrong=self.name.value,
+                wrong=wrong_name,
             )
 
             await interaction.followup.send(

--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -81,7 +81,6 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             else:
                 wrong_name = self.name.value
 
-
             wrong_message = random.choice(settings.wrong_messages).format(
                 user=interaction.user.mention,
                 collectible=settings.collectible_name,

--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -80,6 +80,7 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
                 collectible=settings.collectible_name,
                 ball=self.view.name,
                 collectibles=settings.plural_collectible_name,
+                wrong=self.name.value,
             )
 
             await interaction.followup.send(

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -341,7 +341,9 @@ catch:
 
   # the message that appears when a user gets the name wrong
   # here and only here, you can use {wrong} to show the wrong name that was entered
+  # note that a user can put whatever they want into that field, so be careful
   wrong_msgs:
+    # - {user} Wrong name! You put: {wrong}
     - "{user} Wrong name!"
 
   # the message that appears above the spawn art
@@ -471,16 +473,18 @@ sentry:
 catch:
   # Add any number of messages to each of these categories. The bot will select a random
   # one each time.
-  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and 
+  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and
   # {collectibles} is collectible plural.
 
-  # the message that appears when a user catches a ball 
+  # the message that appears when a user catches a ball
   caught_msgs:
     - "{user} You caught **{ball}**!"
 
   # the message that appears when a user gets the name wrong
   # here and only here, you can use {wrong} to show the wrong name that was entered
+  # note that a user can put whatever they want into that field, so be careful
   wrong_msgs:
+    # - {user} Wrong name! You put: {wrong}
     - "{user} Wrong name!"
 
   # the message that appears above the spawn art

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -334,12 +334,22 @@ catch:
   # one each time.
   # {user} is mention. {collectible} is collectible name. {ball} is ball name, and 
   # {collectibles} is collectible plural.
+
+  # the message that appears when a user catches a ball 
   caught_msgs:
     - "{user} You caught **{ball}**!"
+
+  # the message that appears when a user gets the name wrong
+  # here and only here, you can use {wrong} to show the wrong name that was entered
   wrong_msgs:
     - "{user} Wrong name!"
+
+  # the message that appears above the spawn art
+  # {user} is not available here, because who would it ping?
   spawn_msgs:
     - "A wild {collectible} appeared!"
+
+  # the message that appears when a user is to slow to catch a ball
   slow_msgs:
     - "{user} Sorry, this {collectible} was caught already!"
   """  # noqa: W291
@@ -461,14 +471,24 @@ sentry:
 catch:
   # Add any number of messages to each of these categories. The bot will select a random
   # one each time.
-  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and
+  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and 
   # {collectibles} is collectible plural.
+
+  # the message that appears when a user catches a ball 
   caught_msgs:
     - "{user} You caught **{ball}**!"
+
+  # the message that appears when a user gets the name wrong
+  # here and only here, you can use {wrong} to show the wrong name that was entered
   wrong_msgs:
     - "{user} Wrong name!"
+
+  # the message that appears above the spawn art
+  # {user} is not available here, because who would it ping?
   spawn_msgs:
     - "A wild {collectible} appeared!"
+
+  # the message that appears when a user is to slow to catch a ball
   slow_msgs:
     - "{user} Sorry, this {collectible} was caught already!"
 """


### PR DESCRIPTION
### Description of the changes

This lets the wrong_message field contain a {wrong} replacement, which gets filled with whatever the user inputted incorrectly in the catch view.

Also adds some documentation in the config yaml regarding what each field does.

### Were the changes in this PR tested?

Yep
