### PR TITLE
Remove network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
         condition: service_healthy
     # ports:
     #   - "15260:15260"
-    networks:
-      - internal
     volumes:
       - "./:/code"
     tty: true
@@ -33,8 +31,6 @@ services:
     build: .
     ports:
       - "8000:8000"
-    networks:
-      - internal
     environment:
       - *postgres-url
       # if serving the admin panel online, copy the file "production.example.py" and uncomment
@@ -53,8 +49,6 @@ services:
   migration:
     image: ballsdex
     build: .
-    networks:
-      - internal
     environment:
       - *postgres-url
     volumes:
@@ -81,8 +75,6 @@ services:
     # WARNING: before exposing ports, change the default db password in the .env file!
     # ports:
     #   - "5432:5432"
-    networks:
-      - internal
     volumes:  # Persist the db data
       - database-data:/var/lib/postgresql/data
     healthcheck:
@@ -100,8 +92,6 @@ services:
     depends_on:
       postgres-db:
         condition: service_healthy
-    networks:
-      - internal
     environment:
       - *postgres-db
       - *postgres-user
@@ -129,6 +119,3 @@ services:
 volumes:
   database-data:
   cache-data:
-
-networks:
-  internal:


### PR DESCRIPTION
### Description of the changes

The default behavior of docker compose is to create a single network containing all containers in a compose.yaml; thus there is no need to explicitly create a network. Also, explicitly creating a network makes it more difficult to run multiple dexes, since the internal admin panel / postgres ports collide; this fixes that.

### Were the changes in this PR tested?

Yes, also tested migrating one that had a network to not having one and no extra stuff was needed.
