### PR TITLE
Hot reload config file

### DIFF
--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -99,8 +99,7 @@ class Core(commands.Cog):
         read_settings(Path("./config.yml"))
         await ctx.message.add_reaction("✅")
         await ctx.message.reply(
-            """Config values have been updated.
-            Some changes may require a restart."""
+            """Config values have been updated. Some changes may require a restart."""
         )
 
     @commands.command()

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import discord
@@ -9,7 +10,7 @@ from tortoise import Tortoise
 
 from ballsdex.core.dev import pagify, send_interactive
 from ballsdex.core.models import Ball
-from ballsdex.settings import settings
+from ballsdex.settings import read_settings, settings
 
 log = logging.getLogger("ballsdex.core.commands")
 
@@ -87,6 +88,16 @@ class Core(commands.Cog):
             log.error(f"Failed to reload extension {package}", exc_info=True)
         else:
             await ctx.send("Extension reloaded.")
+
+    @commands.command()
+    @commands.is_owner()
+    async def reloadconf(self, ctx: commands.Context):
+        read_settings(Path("/code/config.yml"))
+        await ctx.message.add_reaction("✅")
+        await ctx.message.reply(
+            """Config values have been updated.
+            Some changes may require a restart."""
+        )
 
     @commands.command()
     @commands.is_owner()

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -92,7 +92,11 @@ class Core(commands.Cog):
     @commands.command()
     @commands.is_owner()
     async def reloadconf(self, ctx: commands.Context):
-        read_settings(Path("/code/config.yml"))
+        """
+        Reload the config file
+        """
+
+        read_settings(Path("./config.yml"))
         await ctx.message.add_reaction("✅")
         await ctx.message.reply(
             """Config values have been updated.


### PR DESCRIPTION
### Description of the changes

This adds a helper command to hot reload the config file. Mostly I've been using this to change spawn messages (which hot reload as expected), but I guess it might be useful for other things as well.

I've heard that BD will switch to TOML for 3.0, but as long as the read_settings function still updates the variables in the settings class, this code should still work fine.

### Were the changes in this PR tested?

Yes
