### PR TITLE
Add filtering by self-caught in completion

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -234,6 +234,7 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         interaction: discord.Interaction["BallsDexBot"],
         user: discord.User | None = None,
         special: SpecialEnabledTransform | None = None,
+        self_caught: bool | None = None,
     ):
         """
         Show your current completion of the BallsDex.
@@ -244,6 +245,8 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The user whose completion you want to view, if not yours.
         special: Special
             The special you want to see the completion of
+        self_caught: bool
+            Filter only for countryballs that the user themself caught/didn't catch (ie no trades)
         """
         user_obj = user or interaction.user
         await interaction.response.defer(thinking=True)
@@ -283,6 +286,10 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
                 for x, y in balls.items()
                 if y.enabled and (special.end_date is None or y.created_at < special.end_date)
             }
+
+        if self_caught is not None:
+            filters["trade_player_id__isnull"] = self_caught
+
         if not bot_countryballs:
             await interaction.followup.send(
                 f"There are no {extra_text}{settings.plural_collectible_name}"
@@ -349,8 +356,13 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
 
         source = FieldPageSource(entries, per_page=5, inline=False, clear_description=False)
         special_str = f" ({special.name})" if special else ""
+        original_catcher_string = (
+            f" ({'not ' if self_caught is False else ''}self-caught)"
+            if self_caught is not None
+            else ""
+        )
         source.embed.description = (
-            f"{settings.bot_name}{special_str} progression: "
+            f"{settings.bot_name}{original_catcher_string}{special_str} progression: "
             f"**{round(len(owned_countryballs) / len(bot_countryballs) * 100, 1)}%**"
         )
         source.embed.colour = discord.Colour.blurple()


### PR DESCRIPTION
### Description of the changes

Allows to filter completion by collectibles that are self caught (ie not received from a trade) or not self caught (ie only received from trade / give)

I used trade_player_id because I think that avoids a SQL join? Not sure it might also be a foreign key. Also, using __isnull because I want to be able to filter for both true and false.

I didn't use FilteringChoices because I would have to refactor this whole function I think, and I'm not sure how I would make it work.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes
