### PR TITLE
Fix missing space in config error message

### DIFF
--- a/ballsdex/__main__.py
+++ b/ballsdex/__main__.py
@@ -276,15 +276,15 @@ def main():
         read_settings(cli_flags.config_file)
     except YAMLError:
         print(
-            "[red]Your YAML is invalid!\nError parsing config file, please check your config and"
-            "try again[/red]"
+            "[red]Your YAML is invalid!\nError parsing config file, please check your config"
+            " and try again[/red]"
         )
         time.sleep(1)
         sys.exit(0)
     except KeyError as missing_key:
         print(
-            f"[red]Config file missing key {missing_key}!\nError parsing config file, please check"
-            "your config and try again[/red]"
+            f"[red]Config file missing key {missing_key}!\nError parsing config file, please"
+            " check your config and try again[/red]"
         )
         time.sleep(1)
         sys.exit(0)


### PR DESCRIPTION
### Description of the changes
Fixes this typo
![image](https://github.com/user-attachments/assets/5223adb3-62ae-4fd3-98f1-03f91e55382a)

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes
(just strings)

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
