### PR TITLE
Update libraqm repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@ config.yml
 .env
 ballsdex.log*
 venv
+.venv
 __pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # Pillow runtime dependencies
 # TODO: remove testing repository when alpine 3.22 is released (libraqm is only on edge for now)
-RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm
+RUN apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
     lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev \
-    libimagequant-dev libxcb-dev libpng-dev libavif-dev libraqm-dev@testing
+    libimagequant-dev libxcb-dev libpng-dev libavif-dev
 
 ARG UID GID
 RUN addgroup -S ballsdex -g ${GID:-1000} && adduser -S ballsdex -G ballsdex -u ${UID:-1000}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # Pillow runtime dependencies
 # TODO: remove testing repository when alpine 3.22 is released (libraqm is only on edge for now)
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm-dev
 RUN apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
     lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev \
     libimagequant-dev libxcb-dev libpng-dev libavif-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ ENV PYTHONFAULTHANDLER=1 \
 
 # Pillow runtime dependencies
 # TODO: remove testing repository when alpine 3.22 is released (libraqm is only on edge for now)
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm-dev
-RUN apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm-dev && \
+    apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
     lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev \
     libimagequant-dev libxcb-dev libpng-dev libavif-dev
 


### PR DESCRIPTION
### Description of the changes

Builds are currently broken because libraqm is in edge community now, not edge testing. So this PR switches to that repo. 

### Were the changes in this PR tested?

Yes
