### PR TITLE
Instead of importing explicitly in migration, grab models from app registry

### DIFF
--- a/admin_panel/bd_models/migrations/0004_check_aerich_migrations_initial.py
+++ b/admin_panel/bd_models/migrations/0004_check_aerich_migrations_initial.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING
 
 import django.db.models.deletion
-from bd_models.models import Economy, Regime, Special
 from django.db import migrations, models
 
 if TYPE_CHECKING:
@@ -12,6 +11,10 @@ if TYPE_CHECKING:
 
 
 def default_models_forward(apps: "Apps", schema_editor: "BaseDatabaseSchemaEditor"):
+    Regime = apps.get_model("bd_models", "Regime")
+    Economy = apps.get_model("bd_models", "Economy")
+    Special = apps.get_model("bd_models", "Special")
+
     default_economies = {
         "Capitalist": "capitalist.png",
         "Communist": "communist.png",
@@ -277,8 +280,9 @@ class Migration(migrations.Migration):
                 (
                     "rarity",
                     models.FloatField(
-                        help_text="Value between 0 and 1, chances of using this "
-                        "special background."
+                        help_text=(
+                            "Value between 0 and 1, chances of using this special background."
+                        )
                     ),
                 ),
                 (
@@ -396,8 +400,10 @@ class Migration(migrations.Migration):
                     "catch_names",
                     models.TextField(
                         blank=True,
-                        help_text="Additional possible names for catching this ball, "
-                        "separated by semicolons",
+                        help_text=(
+                            "Additional possible names for catching this ball, "
+                            "separated by semicolons"
+                        ),
                         null=True,
                     ),
                 ),


### PR DESCRIPTION
### Description of the changes

As per [conversation on discord](https://discord.com/channels/1255250024741212262/1255255977029144596/1395801542078103712) because the  migrations imported from models, trying to add a new column in models would error in 004_check_aerich_migrations because it would try to insert data for a column that would not exist at the time. This fixes that issue so it's again possible to add columns to specials, economies, and regimes.

Also changes formatting on a couple lines because pre-commit was complaining.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes, also tested to make sure I could add new columns and I could.

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->

Should probably test on a DB with content in it already but I didn't have one on hand.
