### PR TITLE
Allow logging with webhooks and remove `log_action`

### DIFF
--- a/ballsdex/core/utils/logging.py
+++ b/ballsdex/core/utils/logging.py
@@ -1,22 +1,73 @@
+import asyncio
 import logging
 
+import aiohttp
 import discord
 
-from ballsdex.core.bot import BallsDexBot
 from ballsdex.settings import settings
 
-log = logging.getLogger("ballsdex.packages.admin.cog")
+log = logging.getLogger("ballsdex.core.utils.logging")
+log.setLevel(logging.INFO)
 
 
-async def log_action(message: str, bot: BallsDexBot, console_log: bool = False):
-    if settings.log_channel:
-        channel = bot.get_channel(settings.log_channel)
-        if not channel:
-            log.warning(f"Channel {settings.log_channel} not found")
-            return
-        if not isinstance(channel, discord.TextChannel):
-            log.warning(f"Channel {channel.name} is not a text channel")  # type: ignore
-            return
-        await channel.send(message)
-    if console_log:
-        log.info(message)
+class WebhookLogger(logging.Handler):
+    """
+    Logs messages via Discord webhooks.
+    """
+
+    def __init__(self, webhook: str):
+        super().__init__(logging.INFO)
+
+        self.session = aiohttp.ClientSession()
+        self.webhook = discord.Webhook.from_url(webhook, session=self.session)
+
+    async def send_to_webhook(self, message: str):
+        try:
+            await self.webhook.send(message)
+        except Exception as error:
+            print("Failed to send message to webhook")
+            print(error)
+
+    def emit(self, record):
+        try:
+            asyncio.create_task(self.send_to_webhook(self.format(record)))
+        except Exception:
+            self.handleError(record)
+
+    def close(self):
+        asyncio.create_task(self.session.close())
+
+
+def init_logger():
+    """
+    Initiates a new `WebhookLogger` and adds it as a handler if `settings.webhook_url` is not None.
+    """
+    if not settings.webhook_url:
+        return
+
+    webhook_logger: WebhookLogger | None = None
+
+    try:
+        webhook_logger = WebhookLogger(settings.webhook_url)
+    except Exception:
+        log.error("An error occured while trying to initialize `WebhookLogger`", exc_info=True)
+        return
+
+    log.addHandler(webhook_logger)
+
+
+async def log_action(message: str):
+    """
+    Logs an action through the `webhook_url` setting.
+    Automatically logs the action to the console if webhook logging is not supported.
+
+    Parameters
+    ----------
+    message: str
+        The message you want to log.
+    """
+    log.propagate = len(log.handlers) == 0
+    log.info(message)
+
+
+init_logger()

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import re
 from pathlib import Path
@@ -13,7 +12,7 @@ from tortoise.exceptions import BaseORMException, DoesNotExist
 from ballsdex.core.bot import BallsDexBot
 from ballsdex.core.models import Ball, BallInstance, Player, Special, Trade, TradeObject
 from ballsdex.core.utils.buttons import ConfirmChoiceView
-from ballsdex.core.utils.logging import log_action
+from ballsdex.core.utils.logging import webhook_logger
 from ballsdex.core.utils.transformers import (
     BallTransform,
     EconomyTransform,
@@ -26,7 +25,8 @@ if TYPE_CHECKING:
     from ballsdex.packages.countryballs.cog import CountryBallsSpawner
     from ballsdex.packages.countryballs.countryball import BallSpawnView
 
-log = logging.getLogger("ballsdex.packages.admin.balls")
+log = webhook_logger("ballsdex.packages.admin.balls")
+
 FILENAME_RE = re.compile(r"^(.+)(\.\S+)$")
 
 
@@ -175,7 +175,7 @@ class Balls(app_commands.Group):
                 atk_bonus,
                 hp_bonus,
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} spawned {settings.collectible_name}"
                 f" {countryball or 'random'} {n} times in {channel or interaction.channel}"
                 + (f" ({", ".join(special_attrs)})." if special_attrs else "."),
@@ -197,7 +197,7 @@ class Balls(app_commands.Group):
             await interaction.followup.send(
                 f"{settings.collectible_name.title()} spawned.", ephemeral=True
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} spawned {settings.collectible_name} {ball.name} "
                 f"in {channel or interaction.channel}"
                 + (f" ({", ".join(special_attrs)})." if special_attrs else "."),
@@ -253,7 +253,7 @@ class Balls(app_commands.Group):
             f"`{user}`.\nSpecial: `{special.name if special else None}` • ATK: "
             f"`{instance.attack_bonus:+d}` • HP:`{instance.health_bonus:+d}` "
         )
-        await log_action(
+        log.info(
             f"{interaction.user} gave {settings.collectible_name} "
             f"{countryball.country} to {user}. (Special={special.name if special else None} "
             f"ATK={instance.attack_bonus:+d} HP={instance.health_bonus:+d}).",
@@ -313,7 +313,7 @@ class Balls(app_commands.Group):
             f"**Traded:** {ball.trade_player}\n{admin_url}",
             ephemeral=True,
         )
-        await log_action(f"{interaction.user} got info for {ball}({ball.pk}).")
+        log.info(f"{interaction.user} got info for {ball}({ball.pk}).")
 
     @app_commands.command(name="delete")
     @app_commands.checks.has_any_role(*settings.root_role_ids)
@@ -346,7 +346,7 @@ class Balls(app_commands.Group):
         await interaction.response.send_message(
             f"{settings.collectible_name.title()} {countryball_id} deleted.", ephemeral=True
         )
-        await log_action(f"{interaction.user} deleted {ball}({ball.pk}).")
+        log.info(f"{interaction.user} deleted {ball}({ball.pk}).")
 
     @app_commands.command(name="transfer")
     @app_commands.checks.has_any_role(*settings.root_role_ids)
@@ -391,7 +391,7 @@ class Balls(app_commands.Group):
             f"Transfered {ball}({ball.pk}) from {original_player} to {user}.",
             ephemeral=True,
         )
-        await log_action(
+        log.info(
             f"{interaction.user} transferred {ball}({ball.pk}) from {original_player} to {user}.",
         )
 
@@ -458,7 +458,7 @@ class Balls(app_commands.Group):
             f"{count} {settings.plural_collectible_name} from {user} have been deleted.",
             ephemeral=True,
         )
-        await log_action(
+        log.info(
             f"{interaction.user} deleted {percentage or 100}% of "
             f"{player}'s {settings.plural_collectible_name}.",
         )

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -179,7 +179,6 @@ class Balls(app_commands.Group):
                 f"{interaction.user} spawned {settings.collectible_name}"
                 f" {countryball or 'random'} {n} times in {channel or interaction.channel}"
                 + (f" ({", ".join(special_attrs)})." if special_attrs else "."),
-                interaction.client,
             )
 
             return
@@ -202,7 +201,6 @@ class Balls(app_commands.Group):
                 f"{interaction.user} spawned {settings.collectible_name} {ball.name} "
                 f"in {channel or interaction.channel}"
                 + (f" ({", ".join(special_attrs)})." if special_attrs else "."),
-                interaction.client,
             )
 
     @app_commands.command()
@@ -259,7 +257,6 @@ class Balls(app_commands.Group):
             f"{interaction.user} gave {settings.collectible_name} "
             f"{countryball.country} to {user}. (Special={special.name if special else None} "
             f"ATK={instance.attack_bonus:+d} HP={instance.health_bonus:+d}).",
-            interaction.client,
         )
 
     @app_commands.command(name="info")
@@ -316,7 +313,7 @@ class Balls(app_commands.Group):
             f"**Traded:** {ball.trade_player}\n{admin_url}",
             ephemeral=True,
         )
-        await log_action(f"{interaction.user} got info for {ball}({ball.pk}).", interaction.client)
+        await log_action(f"{interaction.user} got info for {ball}({ball.pk}).")
 
     @app_commands.command(name="delete")
     @app_commands.checks.has_any_role(*settings.root_role_ids)
@@ -349,7 +346,7 @@ class Balls(app_commands.Group):
         await interaction.response.send_message(
             f"{settings.collectible_name.title()} {countryball_id} deleted.", ephemeral=True
         )
-        await log_action(f"{interaction.user} deleted {ball}({ball.pk}).", interaction.client)
+        await log_action(f"{interaction.user} deleted {ball}({ball.pk}).")
 
     @app_commands.command(name="transfer")
     @app_commands.checks.has_any_role(*settings.root_role_ids)
@@ -396,7 +393,6 @@ class Balls(app_commands.Group):
         )
         await log_action(
             f"{interaction.user} transferred {ball}({ball.pk}) from {original_player} to {user}.",
-            interaction.client,
         )
 
     @app_commands.command(name="reset")
@@ -465,7 +461,6 @@ class Balls(app_commands.Group):
         await log_action(
             f"{interaction.user} deleted {percentage or 100}% of "
             f"{player}'s {settings.plural_collectible_name}.",
-            interaction.client,
         )
 
     @app_commands.command(name="count")

--- a/ballsdex/packages/admin/blacklist.py
+++ b/ballsdex/packages/admin/blacklist.py
@@ -11,10 +11,12 @@ from ballsdex.core.models import (
     GuildConfig,
     Player,
 )
-from ballsdex.core.utils.logging import log_action
+from ballsdex.core.utils.logging import webhook_logger
 from ballsdex.core.utils.paginator import Pages
 from ballsdex.packages.admin.menu import BlacklistViewFormat
 from ballsdex.settings import settings
+
+log = webhook_logger("ballsdex.packages.admin.blacklist")
 
 
 class Blacklist(app_commands.Group):
@@ -59,7 +61,7 @@ class Blacklist(app_commands.Group):
         else:
             interaction.client.blacklist.add(user.id)
             await interaction.response.send_message("User is now blacklisted.", ephemeral=True)
-            await log_action(
+            log.info(
                 f"{interaction.user} blacklisted {user} ({user.id})"
                 f" for the following reason: {reason}.",
             )
@@ -99,7 +101,7 @@ class Blacklist(app_commands.Group):
             await interaction.response.send_message(
                 "User is now removed from blacklist.", ephemeral=True
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} removed blacklist for user {user} ({user.id})."
                 f"\nReason: {reason}",
             )
@@ -237,7 +239,7 @@ class BlacklistGuild(app_commands.Group):
         else:
             interaction.client.blacklist_guild.add(guild.id)
             await interaction.response.send_message("Guild is now blacklisted.", ephemeral=True)
-            await log_action(
+            log.info(
                 f"{interaction.user} blacklisted the guild {guild}({guild.id}) "
                 f"for the following reason: {reason}.",
             )
@@ -293,7 +295,7 @@ class BlacklistGuild(app_commands.Group):
             await interaction.response.send_message(
                 "Guild is now removed from blacklist.", ephemeral=True
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} removed blacklist for guild {guild} ({guild.id}).\n"
                 f"Reason: {reason}",
             )

--- a/ballsdex/packages/admin/blacklist.py
+++ b/ballsdex/packages/admin/blacklist.py
@@ -62,7 +62,6 @@ class Blacklist(app_commands.Group):
             await log_action(
                 f"{interaction.user} blacklisted {user} ({user.id})"
                 f" for the following reason: {reason}.",
-                interaction.client,
             )
 
     @app_commands.command(name="remove")
@@ -103,7 +102,6 @@ class Blacklist(app_commands.Group):
             await log_action(
                 f"{interaction.user} removed blacklist for user {user} ({user.id})."
                 f"\nReason: {reason}",
-                interaction.client,
             )
 
     @app_commands.command(name="info")
@@ -242,7 +240,6 @@ class BlacklistGuild(app_commands.Group):
             await log_action(
                 f"{interaction.user} blacklisted the guild {guild}({guild.id}) "
                 f"for the following reason: {reason}.",
-                interaction.client,
             )
 
     @app_commands.command(name="remove")
@@ -299,7 +296,6 @@ class BlacklistGuild(app_commands.Group):
             await log_action(
                 f"{interaction.user} removed blacklist for guild {guild} ({guild.id}).\n"
                 f"Reason: {reason}",
-                interaction.client,
             )
 
     @app_commands.command(name="info")

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -101,8 +101,6 @@ class Settings:
     root_role_ids: list[int] = field(default_factory=list)
     admin_role_ids: list[int] = field(default_factory=list)
 
-    log_channel: int | None = None
-
     team_owners: bool = False
     co_owners: list[int] = field(default_factory=list)
 
@@ -165,8 +163,6 @@ def read_settings(path: "Path"):
     settings.admin_guild_ids = content["admin-command"]["guild-ids"] or []
     settings.root_role_ids = content["admin-command"]["root-role-ids"] or []
     settings.admin_role_ids = content["admin-command"]["admin-role-ids"] or []
-
-    settings.log_channel = content.get("log-channel", None)
 
     settings.prometheus_enabled = content["prometheus"]["enabled"]
     settings.prometheus_host = content["prometheus"]["host"]
@@ -293,9 +289,6 @@ admin-command:
   # list of role IDs having partial access to /admin
   admin-role-ids:
 
-# log channel for moderation actions
-log-channel:
-
 # manage bot ownership
 owners:
   # if enabled and the application is under a team, all team members will be considered as owners
@@ -314,7 +307,7 @@ admin-panel:
     # client secret of the Discord application (this is not the bot token)
     client-secret: 
 
-    # to get admin notifications from the admin panel, create a Discord webhook and paste the url
+    # to get admin notifications, create a Discord webhook and paste the url
     webhook-url: 
 
     # this will provide some hyperlinks to the admin panel when using /admin commands
@@ -398,6 +391,8 @@ def update_settings(path: "Path"):
     add_sentry = "sentry:" not in content
     add_catch_messages = "catch:" not in content
 
+    remove_log_channel = "log-channel" in content
+
     for line in content.splitlines():
         if line.startswith("owners:"):
             add_owners = False
@@ -479,6 +474,7 @@ admin-panel:
     # to enable Discord OAuth2 login, fill this
     # client ID of the Discord application (not the bot's user ID)
     client-id:
+
     # client secret of the Discord application (this is not the bot token)
     client-secret:
 
@@ -532,6 +528,19 @@ catch:
     - "{user} Sorry, this {collectible} was caught already!"
 """
 
+    if remove_log_channel:
+        log.warning(
+            "Channel logging is no longer supported. "
+            "Please ensure your 'webhook-url' setting is valid to continue using Discord logging."
+        )
+
+        content = "\n".join(
+            line
+            for line in content.splitlines()
+            if not line.strip().startswith("log-channel:")
+            and not line.strip().startswith("# log channel")
+        )
+
     if any(
         (
             add_owners,
@@ -546,6 +555,7 @@ catch:
             add_django,
             add_sentry,
             add_catch_messages,
+            remove_log_channel,
         )
     ):
         path.write_text(content)

--- a/json-config-ref.json
+++ b/json-config-ref.json
@@ -176,14 +176,6 @@
                 }
             }
         },
-        "log-channel": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "description": "ID of the channel to log events to",
-            "$ref": "#/$defs/discord-id"
-        },
         "owners": {
             "type": "object",
             "description": "Manages ownership of the bot",
@@ -264,7 +256,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Link to a Discord webhook for admin panel notifications",
+                    "description": "Link to a Discord webhook for admin notifications",
                     "pattern": "^https://discord.com/api/webhooks/[0-9]{17,22}/[a-zA-Z0-9-_]{68}$"
                 },
                 "url": {


### PR DESCRIPTION
### Description of the changes

This pull request refactors action logging to support webhook logging instead of channels. It introduces a `webhook_logger` function, which automatically attaches a `WebhookLoggingHandler` handler and returns the `Logger`.

Additionally, since `log-channel` is deprecated, config migrations will automatically remove the variable from the config file in favor of `webhook-url`. It will also send a warning indicating that channel logging is deprecated if `log-channel` is found.

Resolves #655 

### Were the changes in this PR tested?

Yes, below is a list of what I have tested.

- [x] Sending a log using `webhook_logger`.
- [x] Checking if `log-channel` is properly removed if it is detected in the config file.
- [x] Attempting to send a log with an invalid webhook.
- [x] Sending a log without a webhook (only sends through console).
- [x] Sending a log that can't be sent through a webhook, such as an empty message.
