### PR TITLE
[config] Add admin-channel-ids to config

### DIFF
--- a/ballsdex/core/utils/utils.py
+++ b/ballsdex/core/utils/utils.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 def is_staff(interaction: discord.Interaction["BallsDexBot"]) -> bool:
     if interaction.user.id in interaction.client.owner_ids:
         return True
+    if interaction.channel_id not in settings.admin_channel_ids:
+        return False
     if interaction.guild and interaction.guild.id in settings.admin_guild_ids:
         roles = settings.admin_role_ids + settings.root_role_ids
         if any(role.id in roles for role in interaction.user.roles):  # type: ignore

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -99,6 +99,7 @@ class Settings:
     admin_guild_ids: list[int] = field(default_factory=list)
     root_role_ids: list[int] = field(default_factory=list)
     admin_role_ids: list[int] = field(default_factory=list)
+    admin_channel_ids: list[int] = field(default_factory=list)
 
     log_channel: int | None = None
 
@@ -164,6 +165,7 @@ def read_settings(path: "Path"):
     settings.admin_guild_ids = content["admin-command"]["guild-ids"] or []
     settings.root_role_ids = content["admin-command"]["root-role-ids"] or []
     settings.admin_role_ids = content["admin-command"]["admin-role-ids"] or []
+    settings.admin_channel_ids = content["admin-command"].get("channel-ids", []) or []
 
     settings.log_channel = content.get("log-channel", None)
 
@@ -286,6 +288,9 @@ admin-command:
 
   # list of role IDs having partial access to /admin
   admin-role-ids:
+
+# list of channel IDs where admins can bypass privacy settings
+  admin-channel-ids:
 
 # log channel for moderation actions
 log-channel:


### PR DESCRIPTION
### Description of the changes

Adds a new entry to admin config, this is for privacy bypassing - meaning staff can only bypass private inventories in a specific channel(s). If left empty, current behaviour is applied

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes
No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
