### PR TITLE
Update player info embed to include statistics

### DIFF
--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -344,25 +344,34 @@ class Player(commands.GroupCog):
             Q(player1__discord_id=interaction.user.id) | Q(player2__discord_id=interaction.user.id)
         ).acount()
         blocks = await Block.objects.filter(player1__discord_id=interaction.user.id).acount()
+        currency_symbol = settings.currency_emoji(self.bot) or settings.currency_symbol
 
         embed = discord.Embed(
             title=f"**{user.display_name.title()}'s {settings.bot_name.title()} Info**", color=discord.Color.blurple()
         )
         embed.description = (
             "Here are your statistics in the bot!\n"
+            "## Player Info\n"
+            f"**Privacy Policy:** {PRIVATE_POLICY_MAP[player.privacy_policy]}\n"
+            f"**Donation Policy:** {DONATION_POLICY_MAP[player.donation_policy]}\n"
+            f"**Mention Policy:** {MENTION_POLICY_MAP[player.mention_policy]}\n"
+            f"**Friend Policy:** {FRIEND_POLICY_MAP[player.friend_policy]}\n"
+            f"**Trade Cooldown Policy:** {TRADE_POLICY_MAP[player.trade_cooldown_policy]}\n"
+            f"**Amount of Friends:** {friends}\n"
+            f"**Amount of Blocked Users:** {blocks}\n"
             "## Player Stats\n"
-            f"**Completion:**\n✔️ {completion_percentage}\n\n"
+            f"**Completion:**\n{completion_percentage}\n\n"
             f"**{settings.plural_collectible_name.title()} Owned:**\n{len(balls_owned):,}\n\n"
             f"**Self-Caught {settings.plural_collectible_name.title()}:**\n{len(caught_owned):,}\n\n"
-            f"**Special {settings.plural_collectible_name.title()}:**\n✨ {len(special):,}\n\n"
-            f"**Trades Completed:**\n📈 {len(trades):,}\n\n"
-            f"**Trade Partners:**\n🤝 {len(trade_partners):,}\n\n"
+            f"**Special {settings.plural_collectible_name.title()}:**\n{len(special):,}\n\n"
+            f"**Trades Completed:**\n{len(trades):,}\n\n"
+            f"**Trade Partners:**\n{len(trade_partners):,}\n\n"
             + (
-                f"**Current Balance:**\n**{settings.currency_symbol} {player.money:,}**"
+                f"**Current Balance:**\n**{currency_symbol} {player.money:,}**"
                 if settings.currency_enabled
                 else ""
             )
         )
         embed.set_footer(text="Keep collecting and trading to improve your stats!")
         embed.set_thumbnail(url=user.display_avatar)  # type: ignore
-        await interaction.followup.send(embed=embed, ephemeral=False)
+        await interaction.followup.send(embed=embed, ephemeral=True)

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -14,6 +14,7 @@ from bd_models.enums import FriendPolicy
 from bd_models.models import BallInstance, Block, Friendship, Trade, balls
 from bd_models.models import Player as PlayerModel
 from settings.models import settings
+from settings.utils import format_currency
 
 from .views import RelationContainer, SettingsContainer
 
@@ -344,7 +345,6 @@ class Player(commands.GroupCog):
             Q(player1__discord_id=interaction.user.id) | Q(player2__discord_id=interaction.user.id)
         ).acount()
         blocks = await Block.objects.filter(player1__discord_id=interaction.user.id).acount()
-        currency_symbol = settings.currency_emoji(self.bot) or settings.currency_symbol
 
         embed = discord.Embed(
             title=f"**{user.display_name.title()}'s {settings.bot_name.title()} Info**", color=discord.Color.blurple()
@@ -367,7 +367,7 @@ class Player(commands.GroupCog):
             f"**Trades Completed:**\n{len(trades):,}\n\n"
             f"**Trade Partners:**\n{len(trade_partners):,}\n\n"
             + (
-                f"**Current Balance:**\n**{currency_symbol} {player.money:,}**"
+                f"**Current Balance:**\n**{format_currency(player.money, bot=self.bot)}**"
                 if settings.currency_enabled
                 else ""
             )

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -349,24 +349,20 @@ class Player(commands.GroupCog):
             title=f"**{user.display_name.title()}'s {settings.bot_name.title()} Info**", color=discord.Color.blurple()
         )
         embed.description = (
-            "Here are your statistics and settings in the bot!\n"
-            "## Player Info\n"
-            f"**Privacy Policy:** {PRIVATE_POLICY_MAP[player.privacy_policy]}\n"
-            f"**Donation Policy:** {DONATION_POLICY_MAP[player.donation_policy]}\n"
-            f"**Mention Policy:** {MENTION_POLICY_MAP[player.mention_policy]}\n"
-            f"**Friend Policy:** {FRIEND_POLICY_MAP[player.friend_policy]}\n"
-            f"**Trade Cooldown Policy:** {TRADE_POLICY_MAP[player.trade_cooldown_policy]}\n"
-            f"**Amount of Friends:** {friends}\n"
-            f"**Amount of Blocked Users:** {blocks}\n"
+            "Here are your statistics in the bot!\n"
             "## Player Stats\n"
-            f"**Completion:** {completion_percentage}\n"
-            f"**{settings.collectible_name.title()}s Owned:** {len(balls_owned):,}\n"
-            f"**Caught {settings.collectible_name.title()}s Owned**: {len(caught_owned):,}\n"
-            f"**Special {settings.collectible_name.title()}s:** {len(special):,}\n"
-            f"**Trades Completed:** {len(trades):,}\n"
-            f"**Amount of Users Traded With:** {len(trade_partners):,}\n"
-            # f"**Current Balance:** {player.money:,}"
+            f"**Completion:**\n✔️ {completion_percentage}\n\n"
+            f"**{settings.plural_collectible_name.title()} Owned:**\n{len(balls_owned):,}\n\n"
+            f"**Self-Caught {settings.plural_collectible_name.title()}:**\n{len(caught_owned):,}\n\n"
+            f"**Special Enemies:**\n✨ {len(special):,}\n\n"
+            f"**Trades Completed:**\n📈 {len(trades):,}\n\n"
+            f"**Trade Partners:**\n🤝 {len(trade_partners):,}\n\n"
+            + (
+                f"**Current Balance:**\n**{settings.currency_symbol} {player.money:,}**"
+                if settings.currency_enabled
+                else ""
+            )
         )
         embed.set_footer(text="Keep collecting and trading to improve your stats!")
         embed.set_thumbnail(url=user.display_avatar)  # type: ignore
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await interaction.followup.send(embed=embed, ephemeral=False)

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -350,7 +350,7 @@ class Player(commands.GroupCog):
             title=f"**{user.display_name.title()}'s {settings.bot_name.title()} Info**", color=discord.Color.blurple()
         )
         embed.description = (
-            "Here are your statistics in the bot!\n"
+            "Here are your settings and statistics in the bot!\n"
             "## Player Info\n"
             f"**Privacy Policy:** {PRIVATE_POLICY_MAP[player.privacy_policy]}\n"
             f"**Donation Policy:** {DONATION_POLICY_MAP[player.donation_policy]}\n"

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -354,7 +354,7 @@ class Player(commands.GroupCog):
             f"**Completion:**\n✔️ {completion_percentage}\n\n"
             f"**{settings.plural_collectible_name.title()} Owned:**\n{len(balls_owned):,}\n\n"
             f"**Self-Caught {settings.plural_collectible_name.title()}:**\n{len(caught_owned):,}\n\n"
-            f"**Special Enemies:**\n✨ {len(special):,}\n\n"
+            f"**Special {settings.plural_collectible_name.title()}:**\n✨ {len(special):,}\n\n"
             f"**Trades Completed:**\n📈 {len(trades):,}\n\n"
             f"**Trade Partners:**\n🤝 {len(trade_partners):,}\n\n"
             + (


### PR DESCRIPTION
Currently, /player info shows both settings and stats, but in V3, /player settings now exists, combining all of your settings into 1 command, meaning it no longer needs to be in /player info. Also, /player info currently is very cluttered, and this makes it look better too! /player info is a great way to simply view all of your current stats and it looks pretty cool too lol. 

### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
