### PR TITLE
[currency] humanized values

### DIFF
--- a/admin_panel/settings/utils.py
+++ b/admin_panel/settings/utils.py
@@ -7,23 +7,24 @@ if TYPE_CHECKING:
 
 
 def format_currency(amount: int, shortened: bool = True, bot: "BallsDexBot | None" = None):
+    humanized = f"{amount:,}"
     if shortened:
         # the emoji takes priority over the symbol, but it can only be resolved with the bot
         emoji = settings.currency_emoji(bot) if bot is not None else None
         if emoji:
             if settings.currency_symbol_before:
-                return f"{emoji} {amount}"
+                return f"{emoji} {humanized}"
             else:
-                return f"{amount} {emoji}"
+                return f"{humanized} {emoji}"
         if settings.currency_symbol:
             if settings.currency_symbol_before:
-                return f"{settings.currency_symbol}{amount}"
+                return f"{settings.currency_symbol}{humanized}"
             else:
-                return f"{amount}{settings.currency_symbol}"
+                return f"{humanized}{settings.currency_symbol}"
         # neither an emoji nor a symbol is configured, fall back to the full form
     if amount == 0:
         return f"no {settings.currency_display_name(bot)}"
     elif amount == 1:
-        return f"{amount} {settings.currency_display_name(bot)}"
+        return f"{humanized} {settings.currency_display_name(bot)}"
     else:
-        return f"{amount} {settings.currency_display_plural(bot)}"
+        return f"{humanized} {settings.currency_display_plural(bot)}"

--- a/ballsdex/packages/admin/money.py
+++ b/ballsdex/packages/admin/money.py
@@ -145,7 +145,7 @@ async def setdefault(ctx: commands.Context[BallsDexBot], amount: int, force: boo
         If true, then ALL users will have their balance reset to the default!
     """
     view = ConfirmChoiceView(ctx)
-    msg = f"You are about to set the new default balance to {amount}.\n"
+    msg = f"You are about to set the new default balance to {amount:,}.\n"
     if force:
         msg += (
             ":warning: You have chosen to reset ALL PLAYERS balance and set it to the new amount. "

--- a/ballsdex/packages/trade/trade.py
+++ b/ballsdex/packages/trade/trade.py
@@ -78,7 +78,8 @@ class SetMoneyModal(Modal, title="Set money offering"):
             await interaction.response.send_message("You have already locked your proposal!", ephemeral=True)
             return
         try:
-            proposal_amount = int(self.proposal.value.strip())
+            # amounts are displayed with thousands separators, accept them back as input
+            proposal_amount = int(self.proposal.value.strip().replace(",", "").replace(" ", ""))
         except ValueError:
             await interaction.response.send_message("This number could not be parsed.", ephemeral=True)
             return


### PR DESCRIPTION
### Description of the changes

Currency amounts were printed raw, so a large balance rendered as `1234567 BallsBux`. This formats them with thousands separators everywhere they are shown to users.

- `format_currency` now humanizes the amount for every branch it returns (emoji form, symbol form and the full `name`/`plural` form), so all of `/balance`, `/give`, the trade menu, trade history and `/admin balls transfer` pick it up for free.
- `/admin money setdefault` humanizes the amount in its confirmation prompt — the rest of the `money` group already did this.
- The trade "Set money offering" modal now strips `,` and spaces before parsing, so an amount copied back out of the bot (`1,000`) is still accepted instead of failing with "This number could not be parsed."

Zero and one are unaffected (`no BallsBux`, `1 BallsBux`), and nothing about how amounts are stored or compared changes — this is display only.

### Were the changes in this PR tested?

- [ ] Yes
- [x] No

Ruff lint/format pass and the formatting branches were checked in isolation (`0` → `no BallsBux`, `1` → `1 BallsBux`, `1234567` → `1,234,567 BallsBux`, `$1,234,567` / `1,234,567$` for the symbol forms), but the bot itself was not run.
