### PR TITLE
[currency] race conditions and utils

### DIFF
--- a/admin_panel/bd_models/models.py
+++ b/admin_panel/bd_models/models.py
@@ -163,17 +163,23 @@ class Player(models.Model):
         return self.mention_policy == MentionPolicy.ALLOW
 
     async def add_money(self, amount: int) -> int:
+        # incremented by the database, not from the in-memory value, so that concurrent
+        # updates cannot overwrite each other
         if amount <= 0:
             raise ValueError("Amount to add must be positive")
-        self.money += amount
-        await self.asave(update_fields=("money",))
+        await Player.objects.filter(pk=self.pk).aupdate(money=F("money") + amount)
+        await self.arefresh_from_db(fields=["money"])
         return self.money
 
     async def remove_money(self, amount: int) -> None:
-        if self.money < amount:
+        # the affordability check is part of the UPDATE, so two concurrent calls cannot both
+        # pass it and overdraw the account
+        if amount <= 0:
+            raise ValueError("Amount to remove must be positive")
+        updated = await Player.objects.filter(pk=self.pk, money__gte=amount).aupdate(money=F("money") - amount)
+        if not updated:
             raise ValueError("Not enough money")
-        self.money -= amount
-        await self.asave(update_fields=("money",))
+        await self.arefresh_from_db(fields=["money"])
 
     def can_afford(self, amount: int) -> bool:
         return self.money >= amount

--- a/admin_panel/settings/utils.py
+++ b/admin_panel/settings/utils.py
@@ -28,3 +28,14 @@ def format_currency(amount: int, shortened: bool = True, bot: "BallsDexBot | Non
         return f"{humanized} {settings.currency_display_name(bot)}"
     else:
         return f"{humanized} {settings.currency_display_plural(bot)}"
+
+
+# separators that `format_currency` may emit, plus the ones a user is likely to type by hand
+_CURRENCY_SEPARATORS = str.maketrans("", "", ", _\N{NO-BREAK SPACE}\N{NARROW NO-BREAK SPACE}")
+
+
+def parse_currency(text: str) -> int:
+    """
+    Parse a user-supplied amount back into an integer, raising `ValueError` if it is not one.
+    """
+    return int(text.strip().translate(_CURRENCY_SEPARATORS))

--- a/ballsdex/packages/admin/money.py
+++ b/ballsdex/packages/admin/money.py
@@ -10,6 +10,7 @@ from ballsdex.core.utils import checks
 from ballsdex.core.utils.buttons import ConfirmChoiceView
 from bd_models.models import Player
 from settings.models import settings
+from settings.utils import format_currency
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +40,9 @@ async def balance(ctx: commands.Context[BallsDexBot], user: discord.User):
         await ctx.send(f"This user does not have a {settings.bot_name} account.", ephemeral=True)
         return
 
-    await ctx.send(f"{user.mention} currently has {player.money:,} coins.", ephemeral=True)
+    await ctx.send(
+        f"{user.mention} currently has {format_currency(player.money, shortened=False, bot=ctx.bot)}.", ephemeral=True
+    )
 
 
 @money.command()
@@ -65,8 +68,9 @@ async def add(ctx: commands.Context[BallsDexBot], user: discord.User, amount: in
         return
 
     await player.add_money(amount)
-    await ctx.send(f"{amount:,} coins have been added to {user.mention}.", ephemeral=True)
-    log.info(f"{ctx.author} ({ctx.author.id}) added {amount:,} coins to {user} ({user.id})", extra={"webhook": True})
+    formatted = format_currency(amount, shortened=False, bot=ctx.bot)
+    await ctx.send(f"Added {formatted} to {user.mention}.", ephemeral=True)
+    log.info(f"{ctx.author} ({ctx.author.id}) added {formatted} to {user} ({user.id})", extra={"webhook": True})
 
 
 @money.command()
@@ -90,14 +94,18 @@ async def remove(ctx: commands.Context[BallsDexBot], user: discord.User, amount:
     if amount <= 0:
         await ctx.send("The amount must be greater than zero.", ephemeral=True)
         return
-    if not player.can_afford(amount):
-        await ctx.send(f"This user does not have enough coins to remove (balance={player.money:,}).", ephemeral=True)
+    try:
+        await player.remove_money(amount)
+    except ValueError:
+        await ctx.send(
+            f"This user does not have enough {settings.currency_display_plural(ctx.bot)} to remove "
+            f"(balance={format_currency(player.money, shortened=False, bot=ctx.bot)}).",
+            ephemeral=True,
+        )
         return
-    await player.remove_money(amount)
-    await ctx.send(f"{amount:,} coins have been removed from {user.mention}.", ephemeral=True)
-    log.info(
-        f"{ctx.author} ({ctx.author.id}) removed {amount:,} coins from {user} ({user.id})", extra={"webhook": True}
-    )
+    formatted = format_currency(amount, shortened=False, bot=ctx.bot)
+    await ctx.send(f"Removed {formatted} from {user.mention}.", ephemeral=True)
+    log.info(f"{ctx.author} ({ctx.author.id}) removed {formatted} from {user} ({user.id})", extra={"webhook": True})
 
 
 @money.command()
@@ -123,11 +131,11 @@ async def set(ctx: commands.Context[BallsDexBot], user: discord.User, amount: in
         return
 
     player.money = amount
-    await player.asave()
-    await ctx.send(f"{user.mention} now has {amount:,} coins.", ephemeral=True)
+    await player.asave(update_fields=("money",))
+    formatted = format_currency(amount, shortened=False, bot=ctx.bot)
+    await ctx.send(f"{user.mention} now has {formatted}.", ephemeral=True)
     log.info(
-        f"{ctx.author} ({ctx.author.id}) set the balance of {user} ({user.id}) to {amount:,} coins",
-        extra={"webhook": True},
+        f"{ctx.author} ({ctx.author.id}) set the balance of {user} ({user.id}) to {formatted}", extra={"webhook": True}
     )
 
 
@@ -145,7 +153,7 @@ async def setdefault(ctx: commands.Context[BallsDexBot], amount: int, force: boo
         If true, then ALL users will have their balance reset to the default!
     """
     view = ConfirmChoiceView(ctx)
-    msg = f"You are about to set the new default balance to {amount:,}.\n"
+    msg = f"You are about to set the new default balance to {format_currency(amount, shortened=False, bot=ctx.bot)}.\n"
     if force:
         msg += (
             ":warning: You have chosen to reset ALL PLAYERS balance and set it to the new amount. "

--- a/ballsdex/packages/money/cog.py
+++ b/ballsdex/packages/money/cog.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
     from ballsdex.core.bot import BallsDexBot
 
 
+class NotEnoughMoney(RuntimeError):
+    """
+    The sender's balance dropped below the donated amount before the transaction locked it.
+    """
+
+
 class Money(commands.GroupCog):
     """
     Currency commands
@@ -41,16 +47,23 @@ class Money(commands.GroupCog):
 
     @transaction.atomic()
     def perform_donation(self, old_player: Player, new_player: Player, amount: int) -> Trade:
-        old_player.refresh_from_db(fields=["money"])
-        if old_player.money < amount:
-            raise RuntimeError(
-                f"Player's balance changed, cannot afford donation anymore {amount=} {old_player.money=}"
-            )
-        old_player.money = F("money") - amount
-        new_player.money = F("money") + amount
-        old_player.save(update_fields=["money"])
-        new_player.save(update_fields=["money"])
-        return Trade.objects.create(player1=old_player, player2=new_player, player1_money=amount)
+        # a plain refresh does not lock, so two concurrent donations could both pass the check
+        # below and overdraw the account. Ordering by primary key keeps two players donating to
+        # each other from deadlocking.
+        locked = {
+            player.pk: player
+            for player in Player.objects.select_for_update()
+            .filter(pk__in=(old_player.pk, new_player.pk))
+            .order_by("pk")
+        }
+        sender, recipient = locked[old_player.pk], locked[new_player.pk]
+        if not sender.can_afford(amount):
+            raise NotEnoughMoney(f"Player's balance changed, cannot afford donation anymore {amount=} {sender.money=}")
+        sender.money = F("money") - amount
+        recipient.money = F("money") + amount
+        sender.save(update_fields=["money"])
+        recipient.save(update_fields=["money"])
+        return Trade.objects.create(player1=sender, player2=recipient, player1_money=amount)
 
     @app_commands.command()
     async def give(self, interaction: discord.Interaction["BallsDexBot"], user: discord.User, amount: int):
@@ -93,7 +106,14 @@ class Money(commands.GroupCog):
             await interaction.followup.send("You cannot donate to a blacklisted user.", ephemeral=True)
             return
 
-        await sync_to_async(self.perform_donation)(old_player, new_player, amount)
+        try:
+            await sync_to_async(self.perform_donation)(old_player, new_player, amount)
+        except NotEnoughMoney:
+            await interaction.followup.send(
+                f"Your balance changed, you do not have enough {settings.currency_display_plural(self.bot)} anymore.",
+                ephemeral=True,
+            )
+            return
         await interaction.followup.send(
             f"You just gave {format_currency(amount, bot=self.bot)} to {user.mention}!",
             allowed_mentions=await can_mention([new_player]),

--- a/ballsdex/packages/trade/trade.py
+++ b/ballsdex/packages/trade/trade.py
@@ -25,7 +25,7 @@ from ballsdex.core.utils.menus import CountryballFormatter, Menu, ModelSource, T
 from bd_models.enums import TradeCooldownPolicy
 from bd_models.models import BallInstance, Player, Trade, TradeObject
 from settings.models import settings
-from settings.utils import format_currency
+from settings.utils import format_currency, parse_currency
 
 from .errors import (
     AlreadyLockedError,
@@ -78,8 +78,7 @@ class SetMoneyModal(Modal, title="Set money offering"):
             await interaction.response.send_message("You have already locked your proposal!", ephemeral=True)
             return
         try:
-            # amounts are displayed with thousands separators, accept them back as input
-            proposal_amount = int(self.proposal.value.strip().replace(",", "").replace(" ", ""))
+            proposal_amount = parse_currency(self.proposal.value)
         except ValueError:
             await interaction.response.send_message("This number could not be parsed.", ephemeral=True)
             return


### PR DESCRIPTION
Follow-up to #842. Fixes three ways a balance could be lost or overdrawn under concurrency, and finishes routing the admin commands through the shared currency helpers.

## Race conditions

**`/money give` could be double-spent.** `perform_donation` read the sender's balance with `refresh_from_db`, which does not take a row lock. Two concurrent donations could both pass the affordability check and then both apply `F("money") - amount`, overdrawing the account (`money` is a `PositiveBigIntegerField`, so this surfaces as an `IntegrityError` at best). Both player rows are now locked with `select_for_update` before the balance is read — the same thing `perform_trade_operation` already does. Rows are locked in primary key order so two players donating to each other cannot deadlock, and the failure case is now reported to the user instead of bubbling up as a command error.

**`Player.add_money` / `remove_money` were lost-update races.** Both did read-modify-write on `self.money`, which may have been fetched long before, with no `F()` and no lock, so a concurrent trade payout and `/money add` would silently drop one of the two. Both now mutate through the database. `remove_money` folds the affordability check into the `UPDATE ... WHERE money >= amount` statement, so it cannot both pass the check and overdraw.

**`/money set` clobbered unrelated columns.** `player.money = amount; await player.asave()` writes every field, reverting any policy the player changed between the fetch and the save. Now passes `update_fields`.

## Currency utils

The admin `money` commands hardcoded the word "coins" and their own `{amount:,}` formatting, so a bot configured with a currency name or emoji still told admins "1,000 coins" while every other surface respected the config. They now go through `format_currency`.

The trade modal parsed thousands separators inline, duplicating knowledge of what `format_currency` emits. That is now `parse_currency`, sitting next to the formatter so the two cannot drift apart. It additionally tolerates underscores and non-breaking spaces.

## Notes

- The `money` command docstrings still say "coins". They are the source of the slash command descriptions, and a docstring cannot be an f-string, so making those configurable needs explicit `description=` arguments — left out of this PR.
- No new pyright diagnostics (verified against the base commit); ruff clean.