### PR TITLE
[docs] Remove ballsdex dependency from custom-package guide

### DIFF
--- a/docs/dev/custom-package.md
+++ b/docs/dev/custom-package.md
@@ -94,14 +94,9 @@ folder that makes development easier.
     [project]
     name = "my_cool_repo"
     version = "1.0.0"
-
-    dependencies = [
-        # you can require a specific version of ballsdex here
-        "ballsdex>=3.0.0",
-    ]
     ```
 
-    You can customize this file later to include extra dependencies and more[^1]
+    You can customize this file later to include dependencies and more[^1]
 
     [^1]: [Python packaging](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
 
@@ -451,11 +446,7 @@ Once your package is ready, you can choose to publish it!
     ]
     readme = "README.md"
 
-    dependencies = [
-        # you can require a specific version of ballsdex here
-        "ballsdex>=3.0.0",
-        # and extra dependencies if needed
-    ]
+    dependencies = [] # you can require dependencies here if needed
 
     [project.urls]
     # put your own links here


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Ballsdex is not a dependency so it shouldn't be in the custom package guide
### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
